### PR TITLE
feat: add material animations

### DIFF
--- a/addons/io_scene_gltf2_msfs/com/material/msfs_material.py
+++ b/addons/io_scene_gltf2_msfs/com/material/msfs_material.py
@@ -113,7 +113,7 @@ class MSFS_Material():
 
     bl_icon = 'SOUND'
 
-    def __init__(self,material):
+    def __init__(self, material):
         self.material = material
         self.node_tree = self.material.node_tree
         self.nodes = self.material.node_tree.nodes
@@ -135,18 +135,18 @@ class MSFS_Material():
             nodes.remove(node)
 
     def refresh(self):
-        self.material.msfs_blend_mode = self.material.msfs_blend_mode
-        self.material.msfs_color_albedo_mix = self.material.msfs_color_albedo_mix
-        self.material.msfs_color_emissive_mix = self.material.msfs_color_emissive_mix
-        self.material.msfs_roughness_scale = self.material.msfs_roughness_scale
-        self.material.msfs_metallic_scale = self.material.msfs_metallic_scale
-        self.material.msfs_normal_scale = self.material.msfs_normal_scale
-        self.material.msfs_alpha_cutoff = self.material.msfs_alpha_cutoff
-        self.material.msfs_detail_uv_scale = self.material.msfs_detail_uv_scale
-        self.material.msfs_detail_uv_offset_x = self.material.msfs_detail_uv_offset_x
-        self.material.msfs_detail_uv_offset_y = self.material.msfs_detail_uv_offset_y
-        self.material.msfs_detail_normal_scale = self.material.msfs_detail_normal_scale
-        self.material.msfs_blend_threshold = self.material.msfs_blend_threshold
+        self.material.msfs_blend_mode.value = self.material.msfs_blend_mode.value
+        self.material.msfs_color_albedo_mix.value = self.material.msfs_color_albedo_mix.value
+        self.material.msfs_color_emissive_mix.value = self.material.msfs_color_emissive_mix.value
+        self.material.msfs_roughness_scale.value = self.material.msfs_roughness_scale.value
+        self.material.msfs_metallic_scale.value = self.material.msfs_metallic_scale.value
+        self.material.msfs_normal_scale.value = self.material.msfs_normal_scale.value
+        self.material.msfs_alpha_cutoff.value = self.material.msfs_alpha_cutoff.value
+        self.material.msfs_detail_uv_scale.value = self.material.msfs_detail_uv_scale.value
+        self.material.msfs_detail_uv_offset_x.value = self.material.msfs_detail_uv_offset_x.value
+        self.material.msfs_detail_uv_offset_y.value = self.material.msfs_detail_uv_offset_y.value
+        self.material.msfs_detail_normal_scale.value = self.material.msfs_detail_normal_scale.value
+        self.material.msfs_blend_threshold.value = self.material.msfs_blend_threshold.value
         
         self.material.msfs_albedo_texture = self.material.msfs_albedo_texture
         self.material.msfs_metallic_texture = self.material.msfs_metallic_texture
@@ -457,7 +457,3 @@ class MSFS_Material():
         #Since Eevee doesn't provide a dither mode, we'll just use alpha-blend instead.
         #It sucks, but what else is there to do?
         self.blend_method = 'BLEND'
-
-    
-
-

--- a/addons/io_scene_gltf2_msfs/com/material/msfs_material_panel.py
+++ b/addons/io_scene_gltf2_msfs/com/material/msfs_material_panel.py
@@ -15,19 +15,16 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import bpy
-from bpy.types import Material
-#from bpy.props import IntProperty, BoolProperty, StringProperty, FloatProperty, EnumProperty, FloatVectorProperty
-#import os
-from .msfs_properties import *
 
+# TODO: centralize these
 animated_properties = [
-        "msfs_color_albedo_mix",
-        "msfs_uv_offset_u",
-        "msfs_uv_offset_v",
-        "msfs_uv_tiling_u",
-        "msfs_uv_tiling_v",
-        "msfs_uv_rotation"
-    ]
+    "msfs_color_albedo_mix",
+    "msfs_uv_offset_u",
+    "msfs_uv_offset_v",
+    "msfs_uv_tiling_u",
+    "msfs_uv_tiling_v",
+    "msfs_uv_rotation"
+]
 
 class MSFS_PT_material(bpy.types.Panel):
     bl_label = "MSFS Material Params"
@@ -41,7 +38,8 @@ class MSFS_PT_material(bpy.types.Panel):
     def poll(cls, context):
         return context.active_object.active_material is not None
 
-    def draw_prop(self, ui_parent, data, prop, text=None, icon=None): # Extracted function to draw a prop, and if it's animated display keframe
+    def draw_prop(self, ui_parent, data, prop, text=None, icon=None): 
+        # Due to how values are enabled to have a keyframe, we have to toggle the use_property_decorate to True and then change it back once we're done
         if prop in animated_properties:
             ui_parent.use_property_decorate = True
 

--- a/addons/io_scene_gltf2_msfs/com/material/msfs_material_panel.py
+++ b/addons/io_scene_gltf2_msfs/com/material/msfs_material_panel.py
@@ -19,6 +19,9 @@ import bpy
 # TODO: centralize these
 animated_properties = [
     "msfs_color_albedo_mix",
+    "msfs_metallic_scale",
+    "msfs_roughness_scale",
+    "msfs_color_emissive_mix",
     "msfs_uv_offset_u",
     "msfs_uv_offset_v",
     "msfs_uv_tiling_u",

--- a/addons/io_scene_gltf2_msfs/com/material/msfs_material_panel.py
+++ b/addons/io_scene_gltf2_msfs/com/material/msfs_material_panel.py
@@ -20,6 +20,14 @@ from bpy.types import Material
 #import os
 from .msfs_properties import *
 
+animated_properties = [
+        "msfs_color_albedo_mix",
+        "msfs_uv_offset_u",
+        "msfs_uv_offset_v",
+        "msfs_uv_tiling_u",
+        "msfs_uv_tiling_v",
+        "msfs_uv_rotation"
+    ]
 
 class MSFS_PT_material(bpy.types.Panel):
     bl_label = "MSFS Material Params"
@@ -33,225 +41,245 @@ class MSFS_PT_material(bpy.types.Panel):
     def poll(cls, context):
         return context.active_object.active_material is not None
 
+    def draw_prop(self, ui_parent, data, prop, text=None, icon=None): # Extracted function to draw a prop, and if it's animated display keframe
+        if prop in animated_properties:
+            ui_parent.use_property_decorate = True
+
+        if icon:
+            ui_parent.prop(data, prop, text=text, icon=icon)
+        else:
+            ui_parent.prop(data, prop, text=text)
+
+        ui_parent.use_property_decorate = False
+
     def draw(self, context):
         mat = context.active_object.active_material
 
         layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
         
         if mat:
-            box=layout.box()
-            box.label(text="Material Mode",icon='MATERIAL')
-            
-            box.prop(mat, 'msfs_material_mode', text="Select")
+            box = layout.box()
+            box.label(text="Material Mode", icon='MATERIAL')
 
-            if mat.msfs_show_tint == True:
-                subbox=box.box()
-                subbox.label(text="Color multipliers",icon='COLOR')
-                row = subbox.row()
-                row.prop(mat, 'msfs_color_albedo_mix')
-                row = subbox.row()
-                row.prop(mat, 'msfs_color_emissive_mix')
-                # subbox.prop(mat, 'msfs_color_alpha_mix')
-                # subbox.prop(mat, 'msfs_color_base_mix')
-                if mat.msfs_show_sss_color == True:
-                    subbox.prop(mat, 'msfs_color_sss')
+            self.draw_prop(box, mat, "msfs_material_mode", text="Select")
 
-            if mat.msfs_show_glass_parameters == True:
+            if mat.msfs_show_tint:
+                box = layout.box()
+                box.label(text="Color multipliers", icon='COLOR')
+
+                self.draw_prop(box, mat, "msfs_color_albedo_mix")
+                self.draw_prop(box, mat, "msfs_color_emissive_mix")
+
+                if mat.msfs_show_sss_color:
+                    self.draw_prop(box, mat, 'msfs_color_sss')
+
+            if mat.msfs_show_glass_parameters:
                 box = layout.box()
                 box.label(text="Glass parameters",icon='SHADING_RENDERED')
-                box.prop(mat, 'msfs_glass_reflection_mask_factor')
-                box.prop(mat, 'msfs_glass_deformation_factor')
 
-            if mat.msfs_show_windshield_options == True:
+                self.draw_prop(box, mat, "msfs_glass_reflection_mask_factor")
+                self.draw_prop(box, mat, "msfs_glass_deformation_factor")
+
+            if mat.msfs_show_windshield_options:
                 box = layout.box()
                 box.label(text="Windshield Options", icon="MATFLUID")
-                box.prop(mat, "msfs_rain_drop_scale")
-                box.prop(mat, "msfs_wiper_1_state")
-                box.prop(mat, "msfs_wiper_2_state")
-                box.prop(mat, "msfs_wiper_3_state")
-                box.prop(mat, "msfs_wiper_4_state")
 
-            if mat.msfs_show_decal_parameters == True:
+                self.draw_prop(box, mat, "msfs_rain_drop_scale")
+                self.draw_prop(box, mat, "msfs_wiper_1_state")
+                self.draw_prop(box, mat, "msfs_wiper_2_state")
+                self.draw_prop(box, mat, "msfs_wiper_3_state")
+                self.draw_prop(box, mat, "msfs_wiper_4_state")
+
+            if mat.msfs_show_decal_parameters:
                 box = layout.box()
                 box.label(text="Decal per component blend factors", icon='OUTLINER_OB_POINTCLOUD')
-                row = box.row()
-                row.prop(mat, 'msfs_decal_blend_factor_color')
-                row.prop(mat, 'msfs_decal_blend_factor_roughness')
-                row = box.row()
-                row.prop(mat, 'msfs_decal_blend_factor_metal')
-                row.prop(mat, 'msfs_decal_blend_factor_occlusion')
-                row = box.row()
-                row.prop(mat, 'msfs_decal_blend_factor_normal')
-                row.prop(mat, 'msfs_decal_blend_factor_emissive')
 
-            if mat.msfs_show_fresnel_parameters == True:
+                row = box.row()
+                self.draw_prop(row, mat, "msfs_decal_blend_factor_color")
+                self.draw_prop(row, mat, "msfs_decal_blend_factor_roughness")
+
+                row = box.row()
+                self.draw_prop(row, mat, 'msfs_decal_blend_factor_metal')
+                self.draw_prop(row, mat, 'msfs_decal_blend_factor_occlusion')
+
+                row = box.row()
+                self.draw_prop(row, mat, 'msfs_decal_blend_factor_normal')
+                self.draw_prop(row, mat, 'msfs_decal_blend_factor_emissive')
+
+            if mat.msfs_show_fresnel_parameters:
                 box = layout.box()
                 box.label(text="Fresnel parameters", icon='COLORSET_13_VEC')
-                box.prop(mat, 'msfs_fresnel_factor')
-                box.prop(mat, 'msfs_fresnel_opacity_bias')
 
-            if mat.msfs_show_parallax_parameters == True:
+                self.draw_prop(box, mat, 'msfs_fresnel_factor')
+                self.draw_prop(box, mat, 'msfs_fresnel_opacity_bias')
+
+            if mat.msfs_show_parallax_parameters:
                 box = layout.box()
                 box.label(text="Parallax parameters",icon='MATERIAL')
-                box.prop(mat,'msfs_parallax_scale')
+
+                self.draw_prop(box, mat, 'msfs_parallax_scale')
+
                 subbox = box.box()
                 subbox.label(text="Room size")
-                subbox.prop(mat,'msfs_parallax_room_size_x')
-                subbox.prop(mat,'msfs_parallax_room_size_y')
-                box.prop(mat,'msfs_parallax_room_number')
-                box.prop(mat,'msfs_parallax_corridor')
+                self.draw_prop(subbox, mat, 'msfs_parallax_room_size_x')
+                self.draw_prop(subbox, mat, 'msfs_parallax_room_size_y')
 
-            if mat.msfs_show_geo_decal_parameters == True:
+                self.draw_prop(box, mat, 'msfs_parallax_room_number')
+                self.draw_prop(box, mat, 'msfs_parallax_corridor')
+
+            if mat.msfs_show_geo_decal_parameters:
                 box = layout.box()
                 box.label(text="Geo Decal Frosted blend factors", icon='FREEZE')
                 row = box.row()
-                row.prop(mat, 'msfs_geo_decal_blend_factor_color')
-                row.prop(mat, 'msfs_geo_decal_blend_factor_roughness')
+                self.draw_prop(row, mat, 'msfs_geo_decal_blend_factor_color')
+                self.draw_prop(row, mat, 'msfs_geo_decal_blend_factor_roughness')
+
                 row = box.row()
-                row.prop(mat, 'msfs_geo_decal_blend_factor_metal')
-                row.prop(mat, 'msfs_geo_decal_blend_factor_blast_sys')
+                self.draw_prop(row, mat, 'msfs_geo_decal_blend_factor_metal')
+                self.draw_prop(row, mat, 'msfs_geo_decal_blend_factor_blast_sys')
+
                 row = box.row()
-                row.prop(mat, 'msfs_geo_decal_blend_factor_normal')
-                row.prop(mat, 'msfs_geo_decal_blend_factor_melt_sys')
+                self.draw_prop(row, mat, 'msfs_geo_decal_blend_factor_normal')
+                self.draw_prop(row, mat, 'msfs_geo_decal_blend_factor_melt_sys')
 
-            
-
-            if (mat.msfs_show_blend_mode == True or mat.msfs_show_draworder == True or mat.msfs_show_no_cast_shadow == True or mat.msfs_show_double_sided == True or 
-                mat.msfs_show_responsive_aa == True or mat.msfs_show_day_night_cycle):
-
+            if (mat.msfs_show_blend_mode or mat.msfs_show_draworder or mat.msfs_show_no_cast_shadow or mat.msfs_show_double_sided or 
+                mat.msfs_show_responsive_aa or mat.msfs_show_day_night_cycle):
                 box = layout.box()
                 box.label(text="Render Parameters",icon='NODE_MATERIAL')
-                if mat.msfs_show_blend_mode == True:
-                    box.prop(mat, 'msfs_blend_mode', text="Alpha mode")
-                if mat.msfs_show_draworder == True:
-                    box.prop(mat, 'msfs_draw_order')
-                if mat.msfs_show_no_cast_shadow == True:
-                    box.prop(mat, 'msfs_no_cast_shadow')
-                if mat.msfs_show_double_sided == True:
-                    box.prop(mat, 'msfs_double_sided')
-                if mat.msfs_show_responsive_aa == True:
-                    box.prop(mat, 'msfs_responsive_aa')
-                if mat.msfs_show_day_night_cycle == True:
-                    box.prop(mat, 'msfs_day_night_cycle')
 
-            if (mat.msfs_show_metallic == True or mat.msfs_show_normal == True or mat.msfs_show_alpha_cutoff == True or mat.msfs_show_detail_albedo == True or
-                mat.msfs_show_detail_normal == True or mat.msfs_show_blend_threshold == True):
+                if mat.msfs_show_blend_mode:
+                    self.draw_prop(box, mat, 'msfs_blend_mode', text="Alpha mode")
+                if mat.msfs_show_draworder:
+                    self.draw_prop(box, mat, 'msfs_draw_order')
+                if mat.msfs_show_no_cast_shadow:
+                    self.draw_prop(box, mat, 'msfs_no_cast_shadow')
+                if mat.msfs_show_double_sided:
+                    self.draw_prop(box, mat, 'msfs_double_sided')
+                if mat.msfs_show_responsive_aa:
+                    self.draw_prop(box, mat, 'msfs_responsive_aa')
+                if mat.msfs_show_day_night_cycle:
+                    self.draw_prop(box, mat, 'msfs_day_night_cycle')
 
+            if (mat.msfs_show_metallic or mat.msfs_show_normal or mat.msfs_show_alpha_cutoff or mat.msfs_show_detail_albedo or
+                mat.msfs_show_detail_normal or mat.msfs_show_blend_threshold):
                 box = layout.box()
                 box.label(text="Material properties", icon='MATERIAL')
-                if mat.msfs_show_metallic == True:
-                    box.prop(mat, 'msfs_roughness_scale')
-                    box.prop(mat, 'msfs_metallic_scale')
-                if mat.msfs_show_normal == True:
-                    box.prop(mat, 'msfs_normal_scale')
-                if mat.msfs_show_alpha_cutoff == True:
-                    box.prop(mat, 'msfs_alpha_cutoff')
-                if mat.msfs_show_detail_albedo == True:
-                    box.prop(mat, 'msfs_detail_uv_scale')
-                    subbox = box.row()
-                    subbox.label(text="Detail UV offset")
-                    row = subbox.row()
-                    row.prop(mat, 'msfs_detail_uv_offset_x')
-                    row.prop(mat, 'msfs_detail_uv_offset_y')
-                if mat.msfs_show_detail_normal == True:
-                    box.prop(mat, 'msfs_detail_normal_scale')
-                if mat.msfs_show_blend_threshold == True:
-                    box.prop(mat, 'msfs_blend_threshold')
-                if mat.msfs_show_emissive == True:
-                    box.prop(mat, 'msfs_emissive_scale')
 
-            if mat.msfs_show_pearl == True:
+                if mat.msfs_show_metallic:
+                    self.draw_prop(box, mat, 'msfs_roughness_scale')
+                    self.draw_prop(box, mat, 'msfs_metallic_scale')
+                if mat.msfs_show_normal:
+                    self.draw_prop(box, mat, 'msfs_normal_scale')
+                if mat.msfs_show_alpha_cutoff:
+                    self.draw_prop(box, mat, 'msfs_alpha_cutoff')
+                if mat.msfs_show_detail_albedo:
+                    self.draw_prop(box, mat, 'msfs_detail_uv_scale')
+
+                    row = box.row()
+                    row.label(text="Detail UV offset")
+                    column = row.column()
+                    self.draw_prop(column, mat, 'msfs_detail_uv_offset_x')
+                    self.draw_prop(column, mat, 'msfs_detail_uv_offset_y')
+                if mat.msfs_show_detail_normal:
+                    self.draw_prop(box, mat, 'msfs_detail_normal_scale')
+                if mat.msfs_show_blend_threshold:
+                    self.draw_prop(box, mat, 'msfs_blend_threshold')
+                if mat.msfs_show_emissive:
+                    self.draw_prop(box, mat, 'msfs_emissive_scale')
+
+            if mat.msfs_show_pearl:
                 box = layout.box()
                 box.label(text="Pearlescent Options", icon="NODE_MATERIAL")
-                box.prop(mat, "msfs_use_pearl_effect")
-                box.prop(mat, "msfs_pearl_shift")
-                box.prop(mat, "msfs_pearl_range")
-                box.prop(mat, "msfs_pearl_brightness")
 
-            if (mat.msfs_show_collision_material == True or mat.msfs_show_road_material == True):
+                self.draw_prop(box, mat, "msfs_use_pearl_effect")
+                self.draw_prop(box, mat, "msfs_pearl_shift")
+                self.draw_prop(box, mat, "msfs_pearl_range")
+                self.draw_prop(box, mat, "msfs_pearl_brightness")
+
+            if (mat.msfs_show_collision_material or mat.msfs_show_road_material):
                 box= layout.box()
                 box.label(text="Gameplay parameters", icon='GHOST_ENABLED')
-                if mat.msfs_show_collision_material == True:
-                    box.prop(mat, 'msfs_collision_material')
-                if mat.msfs_show_road_material == True:
-                    box.prop(mat, 'msfs_road_material')
+                if mat.msfs_show_collision_material:
+                    self.draw_prop(box, mat, 'msfs_collision_material')
+                if mat.msfs_show_road_material:
+                    self.draw_prop(box, mat, 'msfs_road_material')
 
-            if (mat.msfs_show_ao_use_uv2 == True or mat.msfs_show_uv_clamp == True):
+            if (mat.msfs_show_ao_use_uv2 or mat.msfs_show_uv_clamp):
                 box = layout.box()
                 box.label(text="UV options", icon='UV')
-                #if mat.msfs_show_ao_use_uv2 == True:   - removed by Asobo
-                #    box.prop(mat, 'msfs_ao_use_uv2')
-                subbox = box.box()
-                row=subbox.row()
-                row.label(text="UV offset")
-                row.prop(mat,'msfs_uv_offset_u')
-                row.prop(mat,'msfs_uv_offset_v')
-                subbox = box.box()
-                row=subbox.row()
-                row.label(text="UV tiling")
-                row.prop(mat,'msfs_uv_tiling_u')
-                row.prop(mat,'msfs_uv_tiling_v')
-                box.prop(mat, 'msfs_uv_rotation')
-                if mat.msfs_show_uv_clamp == True:
-                    subbox = box.box()
-                    row=subbox.row()
-                    row.label(text="UV clamp")
-                    row.prop(mat,'msfs_uv_clamp_x')
-                    row.prop(mat,'msfs_uv_clamp_y')
-                    #row.prop(mat,'msfs_uv_clamp_z')    - removed by Asobo, probably because it never made sense in the first place.
 
-            if (mat.msfs_show_albedo == True or mat.msfs_show_metallic == True or mat.msfs_show_normal == True or mat.msfs_show_emissive == True or mat.msfs_show_detail_albedo == True or 
-                mat.msfs_show_detail_metallic == True or mat.msfs_show_detail_normal == True or mat.msfs_show_blend_mask == True or mat.msfs_show_anisotropic_direction == True or
-                mat.msfs_show_clearcoat == True or mat.msfs_show_behind_glass == True or mat.msfs_show_wiper_mask == True):
+                row = box.row()
+                row.label(text="UV Offset")
+                column = row.column()
+                self.draw_prop(column, mat, 'msfs_uv_offset_u', text="U")
+                self.draw_prop(column, mat, 'msfs_uv_offset_v', text="V")
+
+                row = box.row()
+                row.label(text="UV Tiling")
+                column = row.column()
+                self.draw_prop(column, mat, 'msfs_uv_tiling_u')
+                self.draw_prop(column, mat, 'msfs_uv_tiling_v')
+
+                self.draw_prop(box, mat, 'msfs_uv_rotation')
+
+                if mat.msfs_show_uv_clamp:
+                    row = box.row()
+                    row.label(text="UV Clamp")
+                    column = row.column()
+                    self.draw_prop(column, mat, 'msfs_uv_clamp_x')
+                    self.draw_prop(column, mat, 'msfs_uv_clamp_y')
+
+            if (mat.msfs_show_albedo or mat.msfs_show_metallic or mat.msfs_show_normal or mat.msfs_show_emissive or mat.msfs_show_detail_albedo or 
+                mat.msfs_show_detail_metallic or mat.msfs_show_detail_normal or mat.msfs_show_blend_mask or mat.msfs_show_anisotropic_direction or
+                mat.msfs_show_clearcoat or mat.msfs_show_behind_glass or mat.msfs_show_wiper_mask):
 
                 box = layout.box()
                 box.label(text="Texture maps",icon='TEXTURE')
-                if mat.msfs_show_albedo == True:
+                if mat.msfs_show_albedo:
                     box.label(text = "Albedo")
                     box.template_ID(mat, "msfs_albedo_texture", new = "image.new", open = "image.open")
-                if mat.msfs_show_metallic == True:
+                if mat.msfs_show_metallic:
                     box.label(text = "Metallic")
                     box.label(text="(Occlusion(R),Roughness(G),Metallic(B))")
                     box.template_ID(mat, "msfs_metallic_texture", new = "image.new", open = "image.open")
-                if mat.msfs_show_normal == True:
+                if mat.msfs_show_normal:
                     box.label(text = "Normal")
                     box.template_ID(mat, "msfs_normal_texture", new = "image.new", open = "image.open")
-                if mat.msfs_show_emissive == True:
+                if mat.msfs_show_emissive:
                     box.label(text = "Emissive")
                     box.template_ID(mat, "msfs_emissive_texture", new = "image.new", open = "image.open")
-                if mat.msfs_show_detail_albedo == True:
+                if mat.msfs_show_detail_albedo:
                     box.label(text = "Detail Albedo")
                     if mat.msfs_material_mode == 'windshield':
                         box.label(text="(Scratches (R), Fingerprints(B))")
                     box.template_ID(mat, "msfs_detail_albedo_texture", new = "image.new", open = "image.open")
-                if mat.msfs_show_detail_metallic == True:
+                if mat.msfs_show_detail_metallic:
                     box.label(text = "Detail Metallic")
                     if mat.msfs_material_mode == 'geo_decal':
                         box.label(text="(Melt Pattern(R),Roughness(G),Metallic(B))")
                     else:
                         box.label(text="(Occlusion(R),Roughness(G),Metallic(B))")
                     box.template_ID(mat, "msfs_detail_metallic_texture", new = "image.new", open = "image.open")
-                if mat.msfs_show_detail_normal == True:
+                if mat.msfs_show_detail_normal:
                     if mat.msfs_material_mode == 'windshield':
                         box.label(text = "Icing Normal")
                     else:
                         box.label(text = "Detail Normal")
                     box.template_ID(mat, "msfs_detail_normal_texture", new = "image.new", open = "image.open")
-                if mat.msfs_show_blend_mask == True:
+                if mat.msfs_show_blend_mask:
                     box.label(text = "Blend Mask")
                     box.template_ID(mat, "msfs_blend_mask_texture", new = "image.new", open = "image.open")
-                if mat.msfs_show_anisotropic_direction == True:
+                if mat.msfs_show_anisotropic_direction:
                     box.label(text=  "Anisotropic direction (RG)")
                     box.template_ID(mat, "msfs_anisotropic_direction_texture", new = "image.new", open = "image.open")
-                if mat.msfs_show_clearcoat == True:
+                if mat.msfs_show_clearcoat:
                     box.label(text=  "Clearcoat amount (R), Clearcoat rough(G)")
                     box.template_ID(mat, "msfs_clearcoat_texture", new = "image.new", open = "image.open")
-                if mat.msfs_show_behind_glass == True:
+                if mat.msfs_show_behind_glass:
                     box.label(text = "Behind glass Albedo")
                     box.template_ID(mat, "msfs_behind_glass_texture", new="image.new", open = "image.open")
-                if mat.msfs_show_wiper_mask == True:
+                if mat.msfs_show_wiper_mask:
                     box.label(text = "Wiper Mask (RG)")
                     box.template_ID(mat, "msfs_wiper_mask_texture", new="image.new", open = "image.open")
-
-
-

--- a/addons/io_scene_gltf2_msfs/com/material/msfs_material_panel.py
+++ b/addons/io_scene_gltf2_msfs/com/material/msfs_material_panel.py
@@ -28,15 +28,15 @@ class MSFS_PT_material(bpy.types.Panel):
     def poll(cls, context):
         return context.active_object.active_material is not None
 
-    def draw_prop(self, ui_parent, data, text=None, icon=None): 
+    def draw_prop(self, ui_parent, prop, text=None, icon=None): 
         # Due to how values are enabled to have a keyframe, we have to toggle the use_property_decorate to True and then change it back once we're done
-        if data.animated:
+        if prop.animated:
             ui_parent.use_property_decorate = True
 
         if icon:
-            ui_parent.prop(data, "value", text=text, icon=icon)
+            ui_parent.prop(prop, "value", text=text, icon=icon)
         else:
-            ui_parent.prop(data, "value", text=text)
+            ui_parent.prop(prop, "value", text=text)
 
         ui_parent.use_property_decorate = False
 

--- a/addons/io_scene_gltf2_msfs/com/material/msfs_material_panel.py
+++ b/addons/io_scene_gltf2_msfs/com/material/msfs_material_panel.py
@@ -16,19 +16,6 @@
 
 import bpy
 
-# TODO: centralize these
-animated_properties = [
-    "msfs_color_albedo_mix",
-    "msfs_metallic_scale",
-    "msfs_roughness_scale",
-    "msfs_color_emissive_mix",
-    "msfs_uv_offset_u",
-    "msfs_uv_offset_v",
-    "msfs_uv_tiling_u",
-    "msfs_uv_tiling_v",
-    "msfs_uv_rotation"
-]
-
 class MSFS_PT_material(bpy.types.Panel):
     bl_label = "MSFS Material Params"
     bl_idname = "MSFSMATERIAL_PT_props"
@@ -41,15 +28,15 @@ class MSFS_PT_material(bpy.types.Panel):
     def poll(cls, context):
         return context.active_object.active_material is not None
 
-    def draw_prop(self, ui_parent, data, prop, text=None, icon=None): 
+    def draw_prop(self, ui_parent, data, text=None, icon=None): 
         # Due to how values are enabled to have a keyframe, we have to toggle the use_property_decorate to True and then change it back once we're done
-        if prop in animated_properties:
+        if data.animated:
             ui_parent.use_property_decorate = True
 
         if icon:
-            ui_parent.prop(data, prop, text=text, icon=icon)
+            ui_parent.prop(data, "value", text=text, icon=icon)
         else:
-            ui_parent.prop(data, prop, text=text)
+            ui_parent.prop(data, "value", text=text)
 
         ui_parent.use_property_decorate = False
 
@@ -64,86 +51,86 @@ class MSFS_PT_material(bpy.types.Panel):
             box = layout.box()
             box.label(text="Material Mode", icon='MATERIAL')
 
-            self.draw_prop(box, mat, "msfs_material_mode", text="Select")
+            self.draw_prop(box, mat.msfs_material_mode, text="Select")
 
             if mat.msfs_show_tint:
                 box = layout.box()
                 box.label(text="Color multipliers", icon='COLOR')
 
-                self.draw_prop(box, mat, "msfs_color_albedo_mix")
-                self.draw_prop(box, mat, "msfs_color_emissive_mix")
+                self.draw_prop(box, mat.msfs_color_albedo_mix)
+                self.draw_prop(box, mat.msfs_color_emissive_mix)
 
                 if mat.msfs_show_sss_color:
-                    self.draw_prop(box, mat, 'msfs_color_sss')
+                    self.draw_prop(box, mat.msfs_color_sss)
 
             if mat.msfs_show_glass_parameters:
                 box = layout.box()
                 box.label(text="Glass parameters",icon='SHADING_RENDERED')
 
-                self.draw_prop(box, mat, "msfs_glass_reflection_mask_factor")
-                self.draw_prop(box, mat, "msfs_glass_deformation_factor")
+                self.draw_prop(box, mat.msfs_glass_reflection_mask_factor)
+                self.draw_prop(box, mat.msfs_glass_deformation_factor)
 
             if mat.msfs_show_windshield_options:
                 box = layout.box()
                 box.label(text="Windshield Options", icon="MATFLUID")
 
-                self.draw_prop(box, mat, "msfs_rain_drop_scale")
-                self.draw_prop(box, mat, "msfs_wiper_1_state")
-                self.draw_prop(box, mat, "msfs_wiper_2_state")
-                self.draw_prop(box, mat, "msfs_wiper_3_state")
-                self.draw_prop(box, mat, "msfs_wiper_4_state")
+                self.draw_prop(box, mat.msfs_rain_drop_scale)
+                self.draw_prop(box, mat.msfs_wiper_1_state)
+                self.draw_prop(box, mat.msfs_wiper_2_state)
+                self.draw_prop(box, mat.msfs_wiper_3_state)
+                self.draw_prop(box, mat.msfs_wiper_4_state)
 
             if mat.msfs_show_decal_parameters:
                 box = layout.box()
                 box.label(text="Decal per component blend factors", icon='OUTLINER_OB_POINTCLOUD')
 
                 row = box.row()
-                self.draw_prop(row, mat, "msfs_decal_blend_factor_color")
-                self.draw_prop(row, mat, "msfs_decal_blend_factor_roughness")
+                self.draw_prop(row, mat.msfs_decal_blend_factor_color)
+                self.draw_prop(row, mat.msfs_decal_blend_factor_roughness)
 
                 row = box.row()
-                self.draw_prop(row, mat, 'msfs_decal_blend_factor_metal')
-                self.draw_prop(row, mat, 'msfs_decal_blend_factor_occlusion')
+                self.draw_prop(row, mat.msfs_decal_blend_factor_metal)
+                self.draw_prop(row, mat.msfs_decal_blend_factor_occlusion)
 
                 row = box.row()
-                self.draw_prop(row, mat, 'msfs_decal_blend_factor_normal')
-                self.draw_prop(row, mat, 'msfs_decal_blend_factor_emissive')
+                self.draw_prop(row, mat.msfs_decal_blend_factor_normal)
+                self.draw_prop(row, mat.msfs_decal_blend_factor_emissive)
 
             if mat.msfs_show_fresnel_parameters:
                 box = layout.box()
                 box.label(text="Fresnel parameters", icon='COLORSET_13_VEC')
 
-                self.draw_prop(box, mat, 'msfs_fresnel_factor')
-                self.draw_prop(box, mat, 'msfs_fresnel_opacity_bias')
+                self.draw_prop(box, mat.msfs_fresnel_factor)
+                self.draw_prop(box, mat.msfs_fresnel_opacity_bias)
 
             if mat.msfs_show_parallax_parameters:
                 box = layout.box()
                 box.label(text="Parallax parameters",icon='MATERIAL')
 
-                self.draw_prop(box, mat, 'msfs_parallax_scale')
+                self.draw_prop(box, mat.msfs_parallax_scale)
 
                 subbox = box.box()
                 subbox.label(text="Room size")
-                self.draw_prop(subbox, mat, 'msfs_parallax_room_size_x')
-                self.draw_prop(subbox, mat, 'msfs_parallax_room_size_y')
+                self.draw_prop(subbox, mat.msfs_parallax_room_size_x)
+                self.draw_prop(subbox, mat.msfs_parallax_room_size_y)
 
-                self.draw_prop(box, mat, 'msfs_parallax_room_number')
-                self.draw_prop(box, mat, 'msfs_parallax_corridor')
+                self.draw_prop(box, mat.msfs_parallax_room_number)
+                self.draw_prop(box, mat.msfs_parallax_corridor)
 
             if mat.msfs_show_geo_decal_parameters:
                 box = layout.box()
                 box.label(text="Geo Decal Frosted blend factors", icon='FREEZE')
                 row = box.row()
-                self.draw_prop(row, mat, 'msfs_geo_decal_blend_factor_color')
-                self.draw_prop(row, mat, 'msfs_geo_decal_blend_factor_roughness')
+                self.draw_prop(row, mat.msfs_geo_decal_blend_factor_color)
+                self.draw_prop(row, mat.msfs_geo_decal_blend_factor_roughness)
 
                 row = box.row()
-                self.draw_prop(row, mat, 'msfs_geo_decal_blend_factor_metal')
-                self.draw_prop(row, mat, 'msfs_geo_decal_blend_factor_blast_sys')
+                self.draw_prop(row, mat.msfs_geo_decal_blend_factor_metal)
+                self.draw_prop(row, mat.msfs_geo_decal_blend_factor_blast_sys)
 
                 row = box.row()
-                self.draw_prop(row, mat, 'msfs_geo_decal_blend_factor_normal')
-                self.draw_prop(row, mat, 'msfs_geo_decal_blend_factor_melt_sys')
+                self.draw_prop(row, mat.msfs_geo_decal_blend_factor_normal)
+                self.draw_prop(row, mat.msfs_geo_decal_blend_factor_melt_sys)
 
             if (mat.msfs_show_blend_mode or mat.msfs_show_draworder or mat.msfs_show_no_cast_shadow or mat.msfs_show_double_sided or 
                 mat.msfs_show_responsive_aa or mat.msfs_show_day_night_cycle):
@@ -151,17 +138,17 @@ class MSFS_PT_material(bpy.types.Panel):
                 box.label(text="Render Parameters",icon='NODE_MATERIAL')
 
                 if mat.msfs_show_blend_mode:
-                    self.draw_prop(box, mat, 'msfs_blend_mode', text="Alpha mode")
+                    self.draw_prop(box, mat.msfs_blend_mode, text="Alpha mode")
                 if mat.msfs_show_draworder:
-                    self.draw_prop(box, mat, 'msfs_draw_order')
+                    self.draw_prop(box, mat.msfs_draw_order)
                 if mat.msfs_show_no_cast_shadow:
-                    self.draw_prop(box, mat, 'msfs_no_cast_shadow')
+                    self.draw_prop(box, mat.msfs_no_cast_shadow)
                 if mat.msfs_show_double_sided:
-                    self.draw_prop(box, mat, 'msfs_double_sided')
+                    self.draw_prop(box, mat.msfs_double_sided)
                 if mat.msfs_show_responsive_aa:
-                    self.draw_prop(box, mat, 'msfs_responsive_aa')
+                    self.draw_prop(box, mat.msfs_responsive_aa)
                 if mat.msfs_show_day_night_cycle:
-                    self.draw_prop(box, mat, 'msfs_day_night_cycle')
+                    self.draw_prop(box, mat.msfs_day_night_cycle)
 
             if (mat.msfs_show_metallic or mat.msfs_show_normal or mat.msfs_show_alpha_cutoff or mat.msfs_show_detail_albedo or
                 mat.msfs_show_detail_normal or mat.msfs_show_blend_threshold):
@@ -169,43 +156,43 @@ class MSFS_PT_material(bpy.types.Panel):
                 box.label(text="Material properties", icon='MATERIAL')
 
                 if mat.msfs_show_metallic:
-                    self.draw_prop(box, mat, 'msfs_roughness_scale')
-                    self.draw_prop(box, mat, 'msfs_metallic_scale')
+                    self.draw_prop(box, mat.msfs_roughness_scale)
+                    self.draw_prop(box, mat.msfs_metallic_scale)
                 if mat.msfs_show_normal:
-                    self.draw_prop(box, mat, 'msfs_normal_scale')
+                    self.draw_prop(box, mat.msfs_normal_scale)
                 if mat.msfs_show_alpha_cutoff:
-                    self.draw_prop(box, mat, 'msfs_alpha_cutoff')
+                    self.draw_prop(box, mat.msfs_alpha_cutoff)
                 if mat.msfs_show_detail_albedo:
-                    self.draw_prop(box, mat, 'msfs_detail_uv_scale')
+                    self.draw_prop(box, mat.msfs_detail_uv_scale)
 
                     row = box.row()
                     row.label(text="Detail UV offset")
                     column = row.column()
-                    self.draw_prop(column, mat, 'msfs_detail_uv_offset_x')
-                    self.draw_prop(column, mat, 'msfs_detail_uv_offset_y')
+                    self.draw_prop(column, mat.msfs_detail_uv_offset_x)
+                    self.draw_prop(column, mat.msfs_detail_uv_offset_y)
                 if mat.msfs_show_detail_normal:
-                    self.draw_prop(box, mat, 'msfs_detail_normal_scale')
+                    self.draw_prop(box, mat.msfs_detail_normal_scale)
                 if mat.msfs_show_blend_threshold:
-                    self.draw_prop(box, mat, 'msfs_blend_threshold')
+                    self.draw_prop(box, mat.msfs_blend_threshold)
                 if mat.msfs_show_emissive:
-                    self.draw_prop(box, mat, 'msfs_emissive_scale')
+                    self.draw_prop(box, mat.msfs_emissive_scale)
 
             if mat.msfs_show_pearl:
                 box = layout.box()
                 box.label(text="Pearlescent Options", icon="NODE_MATERIAL")
 
-                self.draw_prop(box, mat, "msfs_use_pearl_effect")
-                self.draw_prop(box, mat, "msfs_pearl_shift")
-                self.draw_prop(box, mat, "msfs_pearl_range")
-                self.draw_prop(box, mat, "msfs_pearl_brightness")
+                self.draw_prop(box, mat.msfs_use_pearl_effect)
+                self.draw_prop(box, mat.msfs_pearl_shift)
+                self.draw_prop(box, mat.msfs_pearl_range)
+                self.draw_prop(box, mat.msfs_pearl_brightness)
 
             if (mat.msfs_show_collision_material or mat.msfs_show_road_material):
                 box= layout.box()
                 box.label(text="Gameplay parameters", icon='GHOST_ENABLED')
                 if mat.msfs_show_collision_material:
-                    self.draw_prop(box, mat, 'msfs_collision_material')
+                    self.draw_prop(box, mat.msfs_collision_material)
                 if mat.msfs_show_road_material:
-                    self.draw_prop(box, mat, 'msfs_road_material')
+                    self.draw_prop(box, mat.msfs_road_material)
 
             if (mat.msfs_show_ao_use_uv2 or mat.msfs_show_uv_clamp):
                 box = layout.box()
@@ -214,23 +201,23 @@ class MSFS_PT_material(bpy.types.Panel):
                 row = box.row()
                 row.label(text="UV Offset")
                 column = row.column()
-                self.draw_prop(column, mat, 'msfs_uv_offset_u', text="U")
-                self.draw_prop(column, mat, 'msfs_uv_offset_v', text="V")
+                self.draw_prop(column, mat.msfs_uv_offset_u, text="U")
+                self.draw_prop(column, mat.msfs_uv_offset_v, text="V")
 
                 row = box.row()
                 row.label(text="UV Tiling")
                 column = row.column()
-                self.draw_prop(column, mat, 'msfs_uv_tiling_u')
-                self.draw_prop(column, mat, 'msfs_uv_tiling_v')
+                self.draw_prop(column, mat.msfs_uv_tiling_u)
+                self.draw_prop(column, mat.msfs_uv_tiling_v)
 
-                self.draw_prop(box, mat, 'msfs_uv_rotation')
+                self.draw_prop(box, mat.msfs_uv_rotation)
 
                 if mat.msfs_show_uv_clamp:
                     row = box.row()
                     row.label(text="UV Clamp")
                     column = row.column()
-                    self.draw_prop(column, mat, 'msfs_uv_clamp_x')
-                    self.draw_prop(column, mat, 'msfs_uv_clamp_y')
+                    self.draw_prop(column, mat.msfs_uv_clamp_x)
+                    self.draw_prop(column, mat.msfs_uv_clamp_y)
 
             if (mat.msfs_show_albedo or mat.msfs_show_metallic or mat.msfs_show_normal or mat.msfs_show_emissive or mat.msfs_show_detail_albedo or 
                 mat.msfs_show_detail_metallic or mat.msfs_show_detail_normal or mat.msfs_show_blend_mask or mat.msfs_show_anisotropic_direction or

--- a/addons/io_scene_gltf2_msfs/com/material/msfs_material_panel.py
+++ b/addons/io_scene_gltf2_msfs/com/material/msfs_material_panel.py
@@ -28,9 +28,9 @@ class MSFS_PT_material(bpy.types.Panel):
     def poll(cls, context):
         return context.active_object.active_material is not None
 
-    def draw_prop(self, ui_parent, prop, text=None, icon=None): 
+    def draw_prop(self, mat, ui_parent, prop, text=None, icon=None): 
         # Due to how values are enabled to have a keyframe, we have to toggle the use_property_decorate to True and then change it back once we're done
-        if prop.animated:
+        if prop.animated and mat.msfs_material_mode.value == prop.animated_on_type:
             ui_parent.use_property_decorate = True
 
         if icon:
@@ -51,86 +51,86 @@ class MSFS_PT_material(bpy.types.Panel):
             box = layout.box()
             box.label(text="Material Mode", icon='MATERIAL')
 
-            self.draw_prop(box, mat.msfs_material_mode, text="Select")
+            self.draw_prop(mat, box, mat.msfs_material_mode, text="Select")
 
             if mat.msfs_show_tint:
                 box = layout.box()
                 box.label(text="Color multipliers", icon='COLOR')
 
-                self.draw_prop(box, mat.msfs_color_albedo_mix)
-                self.draw_prop(box, mat.msfs_color_emissive_mix)
+                self.draw_prop(mat, box, mat.msfs_color_albedo_mix)
+                self.draw_prop(mat, box, mat.msfs_color_emissive_mix)
 
                 if mat.msfs_show_sss_color:
-                    self.draw_prop(box, mat.msfs_color_sss)
+                    self.draw_prop(mat, box, mat.msfs_color_sss)
 
             if mat.msfs_show_glass_parameters:
                 box = layout.box()
                 box.label(text="Glass parameters",icon='SHADING_RENDERED')
 
-                self.draw_prop(box, mat.msfs_glass_reflection_mask_factor)
-                self.draw_prop(box, mat.msfs_glass_deformation_factor)
+                self.draw_prop(mat, box, mat.msfs_glass_reflection_mask_factor)
+                self.draw_prop(mat, box, mat.msfs_glass_deformation_factor)
 
             if mat.msfs_show_windshield_options:
                 box = layout.box()
                 box.label(text="Windshield Options", icon="MATFLUID")
 
-                self.draw_prop(box, mat.msfs_rain_drop_scale)
-                self.draw_prop(box, mat.msfs_wiper_1_state)
-                self.draw_prop(box, mat.msfs_wiper_2_state)
-                self.draw_prop(box, mat.msfs_wiper_3_state)
-                self.draw_prop(box, mat.msfs_wiper_4_state)
+                self.draw_prop(mat, box, mat.msfs_rain_drop_scale)
+                self.draw_prop(mat, box, mat.msfs_wiper_1_state)
+                self.draw_prop(mat, box, mat.msfs_wiper_2_state)
+                self.draw_prop(mat, box, mat.msfs_wiper_3_state)
+                self.draw_prop(mat, box, mat.msfs_wiper_4_state)
 
             if mat.msfs_show_decal_parameters:
                 box = layout.box()
                 box.label(text="Decal per component blend factors", icon='OUTLINER_OB_POINTCLOUD')
 
                 row = box.row()
-                self.draw_prop(row, mat.msfs_decal_blend_factor_color)
-                self.draw_prop(row, mat.msfs_decal_blend_factor_roughness)
+                self.draw_prop(mat, row, mat.msfs_decal_blend_factor_color)
+                self.draw_prop(mat, row, mat.msfs_decal_blend_factor_roughness)
 
                 row = box.row()
-                self.draw_prop(row, mat.msfs_decal_blend_factor_metal)
-                self.draw_prop(row, mat.msfs_decal_blend_factor_occlusion)
+                self.draw_prop(mat, row, mat.msfs_decal_blend_factor_metal)
+                self.draw_prop(mat, row, mat.msfs_decal_blend_factor_occlusion)
 
                 row = box.row()
-                self.draw_prop(row, mat.msfs_decal_blend_factor_normal)
-                self.draw_prop(row, mat.msfs_decal_blend_factor_emissive)
+                self.draw_prop(mat, row, mat.msfs_decal_blend_factor_normal)
+                self.draw_prop(mat, row, mat.msfs_decal_blend_factor_emissive)
 
             if mat.msfs_show_fresnel_parameters:
                 box = layout.box()
                 box.label(text="Fresnel parameters", icon='COLORSET_13_VEC')
 
-                self.draw_prop(box, mat.msfs_fresnel_factor)
-                self.draw_prop(box, mat.msfs_fresnel_opacity_bias)
+                self.draw_prop(mat, box, mat.msfs_fresnel_factor)
+                self.draw_prop(mat, box, mat.msfs_fresnel_opacity_bias)
 
             if mat.msfs_show_parallax_parameters:
                 box = layout.box()
                 box.label(text="Parallax parameters",icon='MATERIAL')
 
-                self.draw_prop(box, mat.msfs_parallax_scale)
+                self.draw_prop(mat, box, mat.msfs_parallax_scale)
 
                 subbox = box.box()
                 subbox.label(text="Room size")
-                self.draw_prop(subbox, mat.msfs_parallax_room_size_x)
-                self.draw_prop(subbox, mat.msfs_parallax_room_size_y)
+                self.draw_prop(mat, subbox, mat.msfs_parallax_room_size_x)
+                self.draw_prop(mat, subbox, mat.msfs_parallax_room_size_y)
 
-                self.draw_prop(box, mat.msfs_parallax_room_number)
-                self.draw_prop(box, mat.msfs_parallax_corridor)
+                self.draw_prop(mat, box, mat.msfs_parallax_room_number)
+                self.draw_prop(mat, box, mat.msfs_parallax_corridor)
 
             if mat.msfs_show_geo_decal_parameters:
                 box = layout.box()
                 box.label(text="Geo Decal Frosted blend factors", icon='FREEZE')
                 row = box.row()
-                self.draw_prop(row, mat.msfs_geo_decal_blend_factor_color)
-                self.draw_prop(row, mat.msfs_geo_decal_blend_factor_roughness)
+                self.draw_prop(mat, row, mat.msfs_geo_decal_blend_factor_color)
+                self.draw_prop(mat, row, mat.msfs_geo_decal_blend_factor_roughness)
 
                 row = box.row()
-                self.draw_prop(row, mat.msfs_geo_decal_blend_factor_metal)
-                self.draw_prop(row, mat.msfs_geo_decal_blend_factor_blast_sys)
+                self.draw_prop(mat, row, mat.msfs_geo_decal_blend_factor_metal)
+                self.draw_prop(mat, row, mat.msfs_geo_decal_blend_factor_blast_sys)
 
                 row = box.row()
-                self.draw_prop(row, mat.msfs_geo_decal_blend_factor_normal)
-                self.draw_prop(row, mat.msfs_geo_decal_blend_factor_melt_sys)
+                self.draw_prop(mat, row, mat.msfs_geo_decal_blend_factor_normal)
+                self.draw_prop(mat, row, mat.msfs_geo_decal_blend_factor_melt_sys)
 
             if (mat.msfs_show_blend_mode or mat.msfs_show_draworder or mat.msfs_show_no_cast_shadow or mat.msfs_show_double_sided or 
                 mat.msfs_show_responsive_aa or mat.msfs_show_day_night_cycle):
@@ -138,17 +138,17 @@ class MSFS_PT_material(bpy.types.Panel):
                 box.label(text="Render Parameters",icon='NODE_MATERIAL')
 
                 if mat.msfs_show_blend_mode:
-                    self.draw_prop(box, mat.msfs_blend_mode, text="Alpha mode")
+                    self.draw_prop(mat, box, mat.msfs_blend_mode, text="Alpha mode")
                 if mat.msfs_show_draworder:
-                    self.draw_prop(box, mat.msfs_draw_order)
+                    self.draw_prop(mat, box, mat.msfs_draw_order)
                 if mat.msfs_show_no_cast_shadow:
-                    self.draw_prop(box, mat.msfs_no_cast_shadow)
+                    self.draw_prop(mat, box, mat.msfs_no_cast_shadow)
                 if mat.msfs_show_double_sided:
-                    self.draw_prop(box, mat.msfs_double_sided)
+                    self.draw_prop(mat, box, mat.msfs_double_sided)
                 if mat.msfs_show_responsive_aa:
-                    self.draw_prop(box, mat.msfs_responsive_aa)
+                    self.draw_prop(mat, box, mat.msfs_responsive_aa)
                 if mat.msfs_show_day_night_cycle:
-                    self.draw_prop(box, mat.msfs_day_night_cycle)
+                    self.draw_prop(mat, box, mat.msfs_day_night_cycle)
 
             if (mat.msfs_show_metallic or mat.msfs_show_normal or mat.msfs_show_alpha_cutoff or mat.msfs_show_detail_albedo or
                 mat.msfs_show_detail_normal or mat.msfs_show_blend_threshold):
@@ -156,43 +156,43 @@ class MSFS_PT_material(bpy.types.Panel):
                 box.label(text="Material properties", icon='MATERIAL')
 
                 if mat.msfs_show_metallic:
-                    self.draw_prop(box, mat.msfs_roughness_scale)
-                    self.draw_prop(box, mat.msfs_metallic_scale)
+                    self.draw_prop(mat, box, mat.msfs_roughness_scale)
+                    self.draw_prop(mat, box, mat.msfs_metallic_scale)
                 if mat.msfs_show_normal:
-                    self.draw_prop(box, mat.msfs_normal_scale)
+                    self.draw_prop(mat, box, mat.msfs_normal_scale)
                 if mat.msfs_show_alpha_cutoff:
-                    self.draw_prop(box, mat.msfs_alpha_cutoff)
+                    self.draw_prop(mat, box, mat.msfs_alpha_cutoff)
                 if mat.msfs_show_detail_albedo:
-                    self.draw_prop(box, mat.msfs_detail_uv_scale)
+                    self.draw_prop(mat, box, mat.msfs_detail_uv_scale)
 
                     row = box.row()
                     row.label(text="Detail UV offset")
                     column = row.column()
-                    self.draw_prop(column, mat.msfs_detail_uv_offset_x)
-                    self.draw_prop(column, mat.msfs_detail_uv_offset_y)
+                    self.draw_prop(mat, column, mat.msfs_detail_uv_offset_x)
+                    self.draw_prop(mat, column, mat.msfs_detail_uv_offset_y)
                 if mat.msfs_show_detail_normal:
-                    self.draw_prop(box, mat.msfs_detail_normal_scale)
+                    self.draw_prop(mat, box, mat.msfs_detail_normal_scale)
                 if mat.msfs_show_blend_threshold:
-                    self.draw_prop(box, mat.msfs_blend_threshold)
+                    self.draw_prop(mat, box, mat.msfs_blend_threshold)
                 if mat.msfs_show_emissive:
-                    self.draw_prop(box, mat.msfs_emissive_scale)
+                    self.draw_prop(mat, box, mat.msfs_emissive_scale)
 
             if mat.msfs_show_pearl:
                 box = layout.box()
                 box.label(text="Pearlescent Options", icon="NODE_MATERIAL")
 
-                self.draw_prop(box, mat.msfs_use_pearl_effect)
-                self.draw_prop(box, mat.msfs_pearl_shift)
-                self.draw_prop(box, mat.msfs_pearl_range)
-                self.draw_prop(box, mat.msfs_pearl_brightness)
+                self.draw_prop(mat, box, mat.msfs_use_pearl_effect)
+                self.draw_prop(mat, box, mat.msfs_pearl_shift)
+                self.draw_prop(mat, box, mat.msfs_pearl_range)
+                self.draw_prop(mat, box, mat.msfs_pearl_brightness)
 
             if (mat.msfs_show_collision_material or mat.msfs_show_road_material):
                 box= layout.box()
                 box.label(text="Gameplay parameters", icon='GHOST_ENABLED')
                 if mat.msfs_show_collision_material:
-                    self.draw_prop(box, mat.msfs_collision_material)
+                    self.draw_prop(mat, box, mat.msfs_collision_material)
                 if mat.msfs_show_road_material:
-                    self.draw_prop(box, mat.msfs_road_material)
+                    self.draw_prop(mat, box, mat.msfs_road_material)
 
             if (mat.msfs_show_ao_use_uv2 or mat.msfs_show_uv_clamp):
                 box = layout.box()
@@ -201,23 +201,23 @@ class MSFS_PT_material(bpy.types.Panel):
                 row = box.row()
                 row.label(text="UV Offset")
                 column = row.column()
-                self.draw_prop(column, mat.msfs_uv_offset_u, text="U")
-                self.draw_prop(column, mat.msfs_uv_offset_v, text="V")
+                self.draw_prop(mat, column, mat.msfs_uv_offset_u, text="U")
+                self.draw_prop(mat, column, mat.msfs_uv_offset_v, text="V")
 
                 row = box.row()
                 row.label(text="UV Tiling")
                 column = row.column()
-                self.draw_prop(column, mat.msfs_uv_tiling_u)
-                self.draw_prop(column, mat.msfs_uv_tiling_v)
+                self.draw_prop(mat, column, mat.msfs_uv_tiling_u)
+                self.draw_prop(mat, column, mat.msfs_uv_tiling_v)
 
-                self.draw_prop(box, mat.msfs_uv_rotation)
+                self.draw_prop(mat, box, mat.msfs_uv_rotation)
 
                 if mat.msfs_show_uv_clamp:
                     row = box.row()
                     row.label(text="UV Clamp")
                     column = row.column()
-                    self.draw_prop(column, mat.msfs_uv_clamp_x)
-                    self.draw_prop(column, mat.msfs_uv_clamp_y)
+                    self.draw_prop(mat, column, mat.msfs_uv_clamp_x)
+                    self.draw_prop(mat, column, mat.msfs_uv_clamp_y)
 
             if (mat.msfs_show_albedo or mat.msfs_show_metallic or mat.msfs_show_normal or mat.msfs_show_emissive or mat.msfs_show_detail_albedo or 
                 mat.msfs_show_detail_metallic or mat.msfs_show_detail_normal or mat.msfs_show_blend_mask or mat.msfs_show_anisotropic_direction or

--- a/addons/io_scene_gltf2_msfs/com/material/msfs_properties.py
+++ b/addons/io_scene_gltf2_msfs/com/material/msfs_properties.py
@@ -255,7 +255,7 @@ class MSFS_LI_material():
         self["value"] = value
 
     def get_base_color(self):
-        return self["value"]
+        return self.get("value", [1.0, 1.0, 1.0, 1.0])
 
     def set_emissive_color(self, value):
         mat = self.id_data
@@ -271,7 +271,7 @@ class MSFS_LI_material():
         self["value"] = value
 
     def get_emissive_color(self):
-        return self["value"]
+        return self.get("value", [0.0, 0.0, 0.0, 0.0])
 
     def match_emissive_scale(self, context):
         mat = context.active_object.active_material

--- a/addons/io_scene_gltf2_msfs/com/material/msfs_properties.py
+++ b/addons/io_scene_gltf2_msfs/com/material/msfs_properties.py
@@ -240,28 +240,38 @@ class MSFS_LI_material():
             msfs_mat.makeOpaque()
 
     #Update functions for the "tint" parameters:
-    def match_base_color(self, context):
-        mat = context.active_object.active_material
+    def set_base_color(self, value):
+        mat = self.id_data
         nodes = mat.node_tree.nodes
         nodeColorRGB = nodes.get(MSFS_ShaderNodes.baseColorRGB.value)
         if not nodeColorRGB:
             return
         colorValue=nodeColorRGB.outputs[0].default_value
-        colorValue[0] = mat.msfs_color_albedo_mix.value[0]
-        colorValue[1] = mat.msfs_color_albedo_mix.value[1]
-        colorValue[2] = mat.msfs_color_albedo_mix.value[2]
-        nodes.get(MSFS_ShaderNodes.baseColorA.value).outputs[0].default_value =  mat.msfs_color_albedo_mix.value[3]
+        colorValue[0] = value[0]
+        colorValue[1] = value[1]
+        colorValue[2] = value[2]
+        nodes.get(MSFS_ShaderNodes.baseColorA.value).outputs[0].default_value = value[3]
 
-    def match_emissive_color(self, context):
-        mat = context.active_object.active_material
+        self["value"] = value
+
+    def get_base_color(self):
+        return self["value"]
+
+    def set_emissive_color(self, value):
+        mat = self.id_data
         nodes = mat.node_tree.nodes
         nodeEmissiveColorRGB = nodes.get(MSFS_ShaderNodes.emissiveColor.value)
         if not nodeEmissiveColorRGB:
             return
         emissiveValue = nodeEmissiveColorRGB.outputs[0].default_value
-        emissiveValue[0] = mat.msfs_color_emissive_mix.value[0]
-        emissiveValue[1] = mat.msfs_color_emissive_mix.value[1]
-        emissiveValue[2] = mat.msfs_color_emissive_mix.value[2]
+        emissiveValue[0] = value[0]
+        emissiveValue[1] = value[1]
+        emissiveValue[2] = value[2]
+
+        self["value"] = value
+
+    def get_emissive_color(self):
+        return self["value"]
 
     def match_emissive_scale(self, context):
         mat = context.active_object.active_material
@@ -419,7 +429,8 @@ class MSFS_LI_material():
             size=4,
             default=[1.0, 1.0, 1.0, 1.0],
             description="The color value set here will be mixed in with the albedo value of the material.",
-            update=match_base_color,
+            set=set_base_color,
+            get=get_base_color,
         ), animated=True
     )
     Material.msfs_color_emissive_mix = create_material_property_group(
@@ -431,7 +442,8 @@ class MSFS_LI_material():
             size=4,
             default=[0.0, 0.0, 0.0, 0.0],
             description="The color value set here will be mixed in with the emissive value of the material.",
-            update=match_emissive_color,
+            set=set_emissive_color,
+            get=get_emissive_color,
         ), animated=True
     )
     Material.msfs_color_sss = create_material_property_group(

--- a/addons/io_scene_gltf2_msfs/com/material/msfs_properties.py
+++ b/addons/io_scene_gltf2_msfs/com/material/msfs_properties.py
@@ -17,7 +17,7 @@
 
 import bpy
 from bpy.types import Material, Image
-from bpy.props import IntProperty, BoolProperty, FloatProperty, EnumProperty, FloatVectorProperty, PointerProperty
+from bpy.props import IntProperty, BoolProperty, StringProperty, FloatProperty, EnumProperty, FloatVectorProperty, PointerProperty
 
 from .msfs_material import *
 from .msfs_material_standard import *
@@ -328,7 +328,7 @@ class MSFS_LI_material():
             detailUvOffsetVNode.outputs[0].default_value = mat.msfs_detail_uv_offset_y.value
             detailNormalScaleNode.outputs[0].default_value = mat.msfs_detail_normal_scale.value
 
-    def create_material_property_group(value, animated=False):
+    def create_material_property_group(value, animated=False, animated_on_type=""):
         # To make it easier to enable certain material properties to be animated, we need to create a custom property group class with the value and animated property
         property_group = type(
             "MaterialPropertyGroup",
@@ -336,7 +336,8 @@ class MSFS_LI_material():
             {
                 "__annotations__": {
                     "value": value,
-                    "animated": BoolProperty(default=animated)
+                    "animated": BoolProperty(default=animated),
+                    "animated_on_type": StringProperty(default=animated_on_type)
                 }
             }
         )
@@ -431,7 +432,7 @@ class MSFS_LI_material():
             description="The color value set here will be mixed in with the albedo value of the material.",
             set=set_base_color,
             get=get_base_color,
-        ), animated=True
+        ), animated=True, animated_on_type="msfs_standard"
     )
     Material.msfs_color_emissive_mix = create_material_property_group(
         FloatVectorProperty(
@@ -444,7 +445,7 @@ class MSFS_LI_material():
             description="The color value set here will be mixed in with the emissive value of the material.",
             set=set_emissive_color,
             get=get_emissive_color,
-        ), animated=True
+        ), animated=True, animated_on_type="msfs_standard"
     )
     Material.msfs_color_sss = create_material_property_group(
         FloatVectorProperty(
@@ -713,27 +714,27 @@ class MSFS_LI_material():
     Material.msfs_uv_offset_u = create_material_property_group(
         FloatProperty(
             name="U", min=-10.0, max=10.0, default=0.0
-        ), animated=True
+        ), animated=True, animated_on_type="msfs_env_occluder"
     )
     Material.msfs_uv_offset_v = create_material_property_group(
         FloatProperty(
             name="V", min=-10.0, max=10.0, default=0.0
-        ), animated=True
+        ), animated=True, animated_on_type="msfs_env_occluder"
     )
     Material.msfs_uv_tiling_u = create_material_property_group(
         FloatProperty(
             name="U", min=-10.0, max=10.0, default=1.0
-        ), animated=True
+        ), animated=True, animated_on_type="msfs_env_occluder"
     )
     Material.msfs_uv_tiling_v = create_material_property_group(
         FloatProperty(
             name="V", min=-10.0, max=10.0, default=1.0
-        ), animated=True
+        ), animated=True, animated_on_type="msfs_env_occluder"
     )
     Material.msfs_uv_rotation = create_material_property_group(
         FloatProperty(
             name="UV Rotation", min=-360.0, max=360.0, default=0.0
-        ), animated=True
+        ), animated=True, animated_on_type="msfs_env_occluder"
     )
     Material.msfs_ao_use_uv2 = create_material_property_group(
         BoolProperty(
@@ -760,12 +761,12 @@ class MSFS_LI_material():
     Material.msfs_roughness_scale = create_material_property_group(
         FloatProperty(
             name="Roughness scale", min=0, max=1, default=1, update=match_roughness_scale
-        ), animated=True
+        ), animated=True, animated_on_type="msfs_standard"
     )
     Material.msfs_metallic_scale = create_material_property_group(
         FloatProperty(
             name="Metallic scale", min=0, max=1, default=1, update=match_metallic_scale
-        ), animated=True
+        ), animated=True, animated_on_type="msfs_standard"
     )
     Material.msfs_emissive_scale = create_material_property_group(
         FloatProperty(

--- a/addons/io_scene_gltf2_msfs/com/material/msfs_properties.py
+++ b/addons/io_scene_gltf2_msfs/com/material/msfs_properties.py
@@ -17,7 +17,7 @@
 
 import bpy
 from bpy.types import Material, Image
-from bpy.props import IntProperty, BoolProperty, StringProperty, FloatProperty, EnumProperty, FloatVectorProperty, PointerProperty
+from bpy.props import IntProperty, BoolProperty, FloatProperty, EnumProperty, FloatVectorProperty, PointerProperty
 
 from .msfs_material import *
 from .msfs_material_standard import *
@@ -41,49 +41,49 @@ class MSFS_LI_material():
     def switch_msfs_material(self,context):
         mat = context.active_object.active_material
         msfs_mat = None
-        if mat.msfs_material_mode == 'msfs_standard':
+        if mat.msfs_material_mode.value == 'msfs_standard':
             msfs_mat = MSFS_Standard(mat)
             print("Switched to msfs_standard material.")
-        elif mat.msfs_material_mode == 'msfs_anisotropic':
+        elif mat.msfs_material_mode.value == 'msfs_anisotropic':
             msfs_mat =MSFS_Anisotropic(mat)
             print("Switched to msfs_anisotropic material.")
-        elif mat.msfs_material_mode == 'msfs_sss':
+        elif mat.msfs_material_mode.value == 'msfs_sss':
             msfs_mat = MSFS_SSS(mat)
             print("Switched to msfs_sss material.")
-        elif mat.msfs_material_mode == 'msfs_glass':
+        elif mat.msfs_material_mode.value == 'msfs_glass':
             msfs_mat = MSFS_Glass(mat)
             print("Switched to msfs_glass material.")
-        elif mat.msfs_material_mode == 'msfs_decal':
+        elif mat.msfs_material_mode.value == 'msfs_decal':
             msfs_mat = MSFS_Decal(mat)
             print("Switched to msfs_decal material.")
-        elif mat.msfs_material_mode == 'msfs_clearcoat':
+        elif mat.msfs_material_mode.value == 'msfs_clearcoat':
             msfs_mat = MSFS_Clearcoat(mat)
             print("Switched to msfs_clearcoat material.")
-        elif mat.msfs_material_mode == 'msfs_env_occluder':
+        elif mat.msfs_material_mode.value == 'msfs_env_occluder':
             msfs_mat = MSFS_EnvOccluder(mat)
             print("Switched to msfs_env_occluder material.")
-        elif mat.msfs_material_mode == 'msfs_fake_terrain':
+        elif mat.msfs_material_mode.value == 'msfs_fake_terrain':
             msfs_mat = MSFS_FakeTerrain(mat)
             print("Switched to msfs_fake_terrain material.")
-        elif mat.msfs_material_mode == 'msfs_fresnel':
+        elif mat.msfs_material_mode.value == 'msfs_fresnel':
             msfs_mat = MSFS_Fresnel(mat)
             print("Switched to msfs_fresnel material.")
-        elif mat.msfs_material_mode == 'msfs_windshield':
+        elif mat.msfs_material_mode.value == 'msfs_windshield':
             msfs_mat = MSFS_Windshield(mat)            
             print("Switched to msfs_windshield material.")
-        elif mat.msfs_material_mode == 'msfs_porthole':
+        elif mat.msfs_material_mode.value == 'msfs_porthole':
             msfs_mat = MSFS_PortHole(mat)
             print("Switched to msfs_porthole material.")
-        elif mat.msfs_material_mode == 'msfs_parallax':
+        elif mat.msfs_material_mode.value == 'msfs_parallax':
             msfs_mat = MSFS_Parallax(mat)
             print("Switched to msfs_parallax material.")
-        elif mat.msfs_material_mode == 'msfs_geo_decal':
+        elif mat.msfs_material_mode.value == 'msfs_geo_decal':
             msfs_mat = MSFS_GeoDecal(mat)
             print("Switched to msfs_geo_decal material.")
-        elif mat.msfs_material_mode == 'msfs_hair':
+        elif mat.msfs_material_mode.value == 'msfs_hair':
             msfs_mat = MSFS_Hair(mat)
             print("Switched to msfs_hair material.")
-        elif mat.msfs_material_mode == 'msfs_invisible':
+        elif mat.msfs_material_mode.value == 'msfs_invisible':
             msfs_mat = MSFS_Invisible(mat)
             print("Switched to msfs_invisible material.")
         else:
@@ -99,7 +99,7 @@ class MSFS_LI_material():
         base_color_tex = nodes.get(MSFS_ShaderNodes.baseColorTex.value)
         if not base_color_tex:
             return
-        base_color_tex.image = mat.msfs_albedo_texture             
+        base_color_tex.image = mat.msfs_albedo_texture
 
     def match_comp_tex(self, context):
         mat = context.active_object.active_material
@@ -108,7 +108,7 @@ class MSFS_LI_material():
         comp_tex = nodes.get(MSFS_ShaderNodes.compTex.value)
         if not comp_tex:
             return
-        comp_tex.image = mat.msfs_metallic_texture                
+        comp_tex.image = mat.msfs_metallic_texture
 
     def match_normal_tex(self, context):
         mat = context.active_object.active_material
@@ -117,7 +117,7 @@ class MSFS_LI_material():
         normalTex = nodes.get(MSFS_ShaderNodes.normalTex.value)
         if not normalTex:
             return
-        normalTex.image = mat.msfs_normal_texture                  
+        normalTex.image = mat.msfs_normal_texture
 
     def match_emissive_tex(self, context):
         mat = context.active_object.active_material
@@ -126,7 +126,7 @@ class MSFS_LI_material():
         emissiveTex = nodes.get(MSFS_ShaderNodes.emissiveTex.value)
         if not emissiveTex:
             return
-        emissiveTex.image = mat.msfs_emissive_texture                    
+        emissiveTex.image = mat.msfs_emissive_texture
 
     def match_detail_color(self, context):
         mat = context.active_object.active_material
@@ -137,7 +137,7 @@ class MSFS_LI_material():
         if not detailColorTex or not blendColorMapNode:
             return
         detailColorTex.image = mat.msfs_detail_albedo_texture
-        blendColorMapNode.inputs[0].default_value = 0 if mat.msfs_detail_albedo_texture==None else 1 
+        blendColorMapNode.inputs[0].default_value = 0 if mat.msfs_detail_albedo_texture == None else 1
 
     def match_detail_comp(self, context):
         mat = context.active_object.active_material
@@ -147,7 +147,7 @@ class MSFS_LI_material():
         if not detailCompTex or not blendCompMapNode:
             return
         detailCompTex.image = mat.msfs_detail_metallic_texture
-        blendCompMapNode.inputs[0].default_value = 0 if mat.msfs_detail_metallic_texture==None else 1  
+        blendCompMapNode.inputs[0].default_value = 0 if mat.msfs_detail_metallic_texture == None else 1
 
     def match_detail_normal(self, context):
         mat = context.active_object.active_material
@@ -158,7 +158,7 @@ class MSFS_LI_material():
         if not detailNormalTex:
             return
         detailNormalTex.image = mat.msfs_detail_normal_texture
-        blendNormalMapNode.inputs[0].default_value = 0 if mat.msfs_detail_normal_texture==None else 1  
+        blendNormalMapNode.inputs[0].default_value = 0 if mat.msfs_detail_normal_texture == None else 1
 
     def match_blend_mask(self, context):
         mat = context.active_object.active_material
@@ -167,7 +167,7 @@ class MSFS_LI_material():
         if not blendTex:
             return
         blendTex.image = mat.msfs_blend_mask_texture
-        if mat.msfs_material_mode == 'msfs_standard':
+        if mat.msfs_material_mode.value == 'msfs_standard':
             msfs_mat = MSFS_Standard(mat)
             msfs_mat = msfs_mat.toggleVertexBlendMapMask(mat.msfs_blend_mask_texture is None)
 
@@ -228,12 +228,13 @@ class MSFS_LI_material():
 
 
     def switch_msfs_blendmode(self, context):
-        msfs_mat = MSFS_Material(self)
-        if self.msfs_blend_mode == 'BLEND':
+        mat = context.active_object.active_material
+        msfs_mat = MSFS_Material(mat)
+        if mat.msfs_blend_mode.value == 'BLEND':
             msfs_mat.makeAlphaBlend()
-        elif self.msfs_blend_mode == 'MASKED':
+        elif mat.msfs_blend_mode.value == 'MASKED':
             msfs_mat.makeMasked()
-        elif self.msfs_blend_mode == 'DITHER':
+        elif mat.msfs_blend_mode.value == 'DITHER':
             msfs_mat.makeDither()
         else:
             msfs_mat.makeOpaque()
@@ -246,10 +247,10 @@ class MSFS_LI_material():
         if not nodeColorRGB:
             return
         colorValue=nodeColorRGB.outputs[0].default_value
-        colorValue[0]= mat.msfs_color_albedo_mix[0]
-        colorValue[1]= mat.msfs_color_albedo_mix[1]
-        colorValue[2]= mat.msfs_color_albedo_mix[2]
-        nodes.get(MSFS_ShaderNodes.baseColorA.value).outputs[0].default_value =  mat.msfs_color_albedo_mix[3]
+        colorValue[0] = mat.msfs_color_albedo_mix.value[0]
+        colorValue[1] = mat.msfs_color_albedo_mix.value[1]
+        colorValue[2] = mat.msfs_color_albedo_mix.value[2]
+        nodes.get(MSFS_ShaderNodes.baseColorA.value).outputs[0].default_value =  mat.msfs_color_albedo_mix.value[3]
 
     def match_emissive_color(self, context):
         mat = context.active_object.active_material
@@ -258,9 +259,9 @@ class MSFS_LI_material():
         if not nodeEmissiveColorRGB:
             return
         emissiveValue = nodeEmissiveColorRGB.outputs[0].default_value
-        emissiveValue[0]= mat.msfs_color_emissive_mix[0]
-        emissiveValue[1]= mat.msfs_color_emissive_mix[1]
-        emissiveValue[2]= mat.msfs_color_emissive_mix[2]
+        emissiveValue[0] = mat.msfs_color_emissive_mix.value[0]
+        emissiveValue[1] = mat.msfs_color_emissive_mix.value[1]
+        emissiveValue[2] = mat.msfs_color_emissive_mix.value[2]
 
     def match_emissive_scale(self, context):
         mat = context.active_object.active_material
@@ -268,41 +269,41 @@ class MSFS_LI_material():
         emissiveScale =nodes.get(MSFS_ShaderNodes.emissiveScale.value)
         if not emissiveScale:
             return
-        emissiveScale.outputs[0].default_value =  mat.msfs_emissive_scale
+        emissiveScale.outputs[0].default_value = mat.msfs_emissive_scale.value
 
     def match_metallic_scale(self, context):
         mat = context.active_object.active_material
         nodes = mat.node_tree.nodes
         node = nodes.get(MSFS_ShaderNodes.metallicScale.value)
         if node:
-            node.outputs[0].default_value =  mat.msfs_metallic_scale
+            node.outputs[0].default_value = mat.msfs_metallic_scale.value
 
     def match_roughness_scale(self, context):
         mat = context.active_object.active_material
         nodes = mat.node_tree.nodes
         node =nodes.get(MSFS_ShaderNodes.roughnessScale.value)
         if node:
-            node.outputs[0].default_value =  mat.msfs_roughness_scale
+            node.outputs[0].default_value = mat.msfs_roughness_scale.value
 
     def match_normal_scale(self, context):
         mat = context.active_object.active_material
         nodes = mat.node_tree.nodes
         node = nodes.get(MSFS_ShaderNodes.normalScale.value)
         if node:
-            node.outputs[0].default_value =  mat.msfs_normal_scale
+            node.outputs[0].default_value = mat.msfs_normal_scale.value
 
     def update_color_sss(self, context):
         mat = context.active_object.active_material
         if mat.node_tree.nodes.get("bsdf", None) != None:
-            mat.node_tree.nodes["bsdf"].inputs.get("Subsurface Color").default_value = mat.msfs_color_sss
+            mat.node_tree.nodes["bsdf"].inputs.get("Subsurface Color").default_value = mat.msfs_color_sss.value
 
     def update_double_sided(self, context):
         mat = context.active_object.active_material
-        mat.use_backface_culling = not mat.msfs_double_sided
+        mat.use_backface_culling = not mat.msfs_double_sided.value
 
     def match_alpha_cutoff(self,context):
         mat = context.active_object.active_material
-        mat.alpha_threshold = mat.msfs_alpha_cutoff
+        mat.alpha_threshold = mat.msfs_alpha_cutoff.value
 
     def match_detail_uv(self,context):
         mat = context.active_object.active_material
@@ -312,173 +313,307 @@ class MSFS_LI_material():
         detailUvOffsetVNode = nodes.get(MSFS_ShaderNodes.detailUVOffsetV.value)
         detailNormalScaleNode = nodes.get(MSFS_ShaderNodes.detailNormalScale.value)
         if detailUvScaleNode and detailUvOffsetUNode and detailUvOffsetVNode and detailNormalScaleNode:
-            detailUvScaleNode.outputs[0].default_value =  mat.msfs_detail_uv_scale
-            detailUvOffsetUNode.outputs[0].default_value =  mat.msfs_detail_uv_offset_x
-            detailUvOffsetVNode.outputs[0].default_value =  mat.msfs_detail_uv_offset_y
-            detailNormalScaleNode.outputs[0].default_value =  mat.msfs_detail_normal_scale
-        
+            detailUvScaleNode.outputs[0].default_value = mat.msfs_detail_uv_scale.value
+            detailUvOffsetUNode.outputs[0].default_value = mat.msfs_detail_uv_offset_x.value
+            detailUvOffsetVNode.outputs[0].default_value = mat.msfs_detail_uv_offset_y.value
+            detailNormalScaleNode.outputs[0].default_value = mat.msfs_detail_normal_scale.value
 
+    def create_material_property_group(value, animated=False):
+        # To make it easier to enable certain material properties to be animated, we need to create a custom property group class with the value and animated property
+        property_group = type(
+            "MaterialPropertyGroup",
+            (bpy.types.PropertyGroup,),
+            {
+                "__annotations__": {
+                    "value": value,
+                    "animated": BoolProperty(default=animated)
+                }
+            }
+        )
 
-    # Main material mode, in accordance with MSFS material shaders:
-    Material.msfs_material_mode =  bpy.props.EnumProperty(items=(('NONE',"Disabled",""),
-                                                                ('msfs_standard', "MSFS Standard",""),
-                                                                ('msfs_anisotropic', "MSFS Anisotropic",""),
-                                                                ('msfs_sss', "MSFS Subsurface Scattering",""),
-                                                                ('msfs_glass', "MSFS Glass",""),
-                                                                ('msfs_decal', "MSFS Decal",""),
-                                                                ('msfs_clearcoat', "MSFS Clearcoat",""),
-                                                                ('msfs_env_occluder', "MSFS Environment Occluder",""),
-                                                                ('msfs_fake_terrain', "MSFS Fake Terrain",""),
-                                                                ('msfs_fresnel', "MSFS Fresnel Blending",""),
-                                                                ('msfs_windshield', "MSFS Windshield",""),
-                                                                ('msfs_porthole', "MSFS Porthole",""),
-                                                                ('msfs_parallax', "MSFS Parallax",""),
-                                                                ('msfs_geo_decal', "MSFS Geo Decal Frosted",""),
-                                                                ('msfs_hair', "MSFS Hair",""),
-                                                                ('msfs_invisible', "MSFS Invisible",""),), default='NONE',update=switch_msfs_material,)
+        bpy.utils.register_class(property_group)
+
+        return PointerProperty(type=property_group)     
+
 
     # Some flags to control the visibility of all of the paramters in the UI. 
     # Note: they don't control the actualy material parameters, only whether or 
     # not those parameters are being displayed. 
-    Material.msfs_show_tint = bpy.props.BoolProperty(name="show_tint",default=False)
-    Material.msfs_show_sss_color = bpy.props.BoolProperty(name="show_sss_color",default=False)
+    Material.msfs_show_tint = BoolProperty(name="show_tint",default=False)
+    Material.msfs_show_sss_color = BoolProperty(name="show_sss_color",default=False)
 
-    Material.msfs_show_glass_parameters = bpy.props.BoolProperty(name="show_glass_parameters",default=False)
-    Material.msfs_show_windshield_options = bpy.props.BoolProperty(name="show_glass_parameters",default=False)
-    Material.msfs_show_decal_parameters = bpy.props.BoolProperty(name="show_decal_parameters",default=False)
-    Material.msfs_show_fresnel_parameters = bpy.props.BoolProperty(name="show_fresnel_parameters",default=False)
-    Material.msfs_show_parallax_parameters = bpy.props.BoolProperty(name="show_parallax_parameters",default=False)
-    Material.msfs_show_geo_decal_parameters = bpy.props.BoolProperty(name="show_geo_decal_parameters",default=False)
+    Material.msfs_show_glass_parameters = BoolProperty(name="show_glass_parameters",default=False)
+    Material.msfs_show_windshield_options = BoolProperty(name="show_glass_parameters",default=False)
+    Material.msfs_show_decal_parameters = BoolProperty(name="show_decal_parameters",default=False)
+    Material.msfs_show_fresnel_parameters = BoolProperty(name="show_fresnel_parameters",default=False)
+    Material.msfs_show_parallax_parameters = BoolProperty(name="show_parallax_parameters",default=False)
+    Material.msfs_show_geo_decal_parameters = BoolProperty(name="show_geo_decal_parameters",default=False)
 
-    Material.msfs_show_albedo = bpy.props.BoolProperty(name="show_albedo",default=False)
-    Material.msfs_show_metallic = bpy.props.BoolProperty(name="show_metallic",default=False)
-    Material.msfs_show_normal = bpy.props.BoolProperty(name="show_normal",default=False)
-    Material.msfs_show_emissive = bpy.props.BoolProperty(name="show_emissive",default=False)
-    Material.msfs_show_detail_albedo = bpy.props.BoolProperty(name="show_detail_albedo",default=False)
-    Material.msfs_show_detail_metallic = bpy.props.BoolProperty(name="show_detail_metallic",default=False)
-    Material.msfs_show_detail_normal = bpy.props.BoolProperty(name="show_detail_normal",default=False)
-    Material.msfs_show_blend_mask = bpy.props.BoolProperty(name="show_blend_mask",default=False)
-    Material.msfs_show_anisotropic_direction = bpy.props.BoolProperty(name="show_anisotropic_direction",default=False)
-    Material.msfs_show_clearcoat = bpy.props.BoolProperty(name="show_clearcoat",default=False)
-    Material.msfs_show_behind_glass = bpy.props.BoolProperty(name="show_behind_glass",default=False)
-    Material.msfs_show_wiper_mask = bpy.props.BoolProperty(name="show_wiper_mask",default=False)
+    Material.msfs_show_albedo = BoolProperty(name="show_albedo",default=False)
+    Material.msfs_show_metallic = BoolProperty(name="show_metallic",default=False)
+    Material.msfs_show_normal = BoolProperty(name="show_normal",default=False)
+    Material.msfs_show_emissive = BoolProperty(name="show_emissive",default=False)
+    Material.msfs_show_detail_albedo = BoolProperty(name="show_detail_albedo",default=False)
+    Material.msfs_show_detail_metallic = BoolProperty(name="show_detail_metallic",default=False)
+    Material.msfs_show_detail_normal = BoolProperty(name="show_detail_normal",default=False)
+    Material.msfs_show_blend_mask = BoolProperty(name="show_blend_mask",default=False)
+    Material.msfs_show_anisotropic_direction = BoolProperty(name="show_anisotropic_direction",default=False)
+    Material.msfs_show_clearcoat = BoolProperty(name="show_clearcoat",default=False)
+    Material.msfs_show_behind_glass = BoolProperty(name="show_behind_glass",default=False)
+    Material.msfs_show_wiper_mask = BoolProperty(name="show_wiper_mask",default=False)
 
-    Material.msfs_show_blend_mode = bpy.props.BoolProperty(name="show_blend_mode",default=False)
+    Material.msfs_show_blend_mode = BoolProperty(name="show_blend_mode",default=False)
 
-    Material.msfs_show_draworder = bpy.props.BoolProperty(name="show_draworder",default=False)
-    Material.msfs_show_no_cast_shadow = bpy.props.BoolProperty(name="show_no_cast_shadow",default=False)
-    Material.msfs_show_double_sided = bpy.props.BoolProperty(name="show_double_sided",default=False)
-    Material.msfs_show_responsive_aa = bpy.props.BoolProperty(name="show_responsive_aa",default=False)
-    Material.msfs_show_day_night_cycle = bpy.props.BoolProperty(name="show_day_night_cycle",default=False)
+    Material.msfs_show_draworder = BoolProperty(name="show_draworder",default=False)
+    Material.msfs_show_no_cast_shadow = BoolProperty(name="show_no_cast_shadow",default=False)
+    Material.msfs_show_double_sided = BoolProperty(name="show_double_sided",default=False)
+    Material.msfs_show_responsive_aa = BoolProperty(name="show_responsive_aa",default=False)
+    Material.msfs_show_day_night_cycle = BoolProperty(name="show_day_night_cycle",default=False)
 
-    Material.msfs_show_collision_material = bpy.props.BoolProperty(name="show_collision_material",default=False)
-    Material.msfs_show_road_material = bpy.props.BoolProperty(name="show_road_material",default=False)
+    Material.msfs_show_collision_material = BoolProperty(name="show_collision_material",default=False)
+    Material.msfs_show_road_material = BoolProperty(name="show_road_material",default=False)
 
-    Material.msfs_show_ao_use_uv2 = bpy.props.BoolProperty(name="show_ao_use_uv2",default=False)
-    Material.msfs_show_uv_clamp = bpy.props.BoolProperty(name="show_uv_clamp",default=False)
+    Material.msfs_show_ao_use_uv2 = BoolProperty(name="show_ao_use_uv2",default=False)
+    Material.msfs_show_uv_clamp = BoolProperty(name="show_uv_clamp",default=False)
 
-    Material.msfs_show_alpha_cutoff = bpy.props.BoolProperty(name="show_alpha_cutoff",default=False)
-    Material.msfs_show_blend_threshold = bpy.props.BoolProperty(name="show_blend_threshold",default=False)
-    Material.msfs_show_pearl = bpy.props.BoolProperty(name="show_pearl",default=False)
+    Material.msfs_show_alpha_cutoff = BoolProperty(name="show_alpha_cutoff",default=False)
+    Material.msfs_show_blend_threshold = BoolProperty(name="show_blend_threshold",default=False)
+    Material.msfs_show_pearl = BoolProperty(name="show_pearl",default=False)
 
     # MSFS Material properties
     # The following variables are written into the glTF file when exporting.
-    #Color blends:
-    Material.msfs_color_albedo_mix = bpy.props.FloatVectorProperty(name="Albedo Color", subtype='COLOR', min=0.0, max=1.0,size=4,default=[1.0,1.0,1.0,1.0], description="The color value set here will be mixed in with the albedo value of the material.",update=match_base_color)
-    Material.msfs_color_emissive_mix = bpy.props.FloatVectorProperty(name="Emissive Color", subtype='COLOR', min=0.0, max=1.0, size=4,default=[0.0,0.0,0.0,0.0], description="The color value set here will be mixed in with the emissive value of the material.", update=match_emissive_color)
-    # Material.msfs_color_alpha_mix = bpy.props.FloatProperty(name="Alpha multiplier", min=0, max=1, default=1, description="The alpha value set here will be mixed in with the Alpha value of the texture.",update=update_color_alpha_mix)
-    # Material.msfs_color_base_mix = bpy.props.FloatProperty(name="Albedo Color Mix", min=0, max=1, default=1, description="Mix factor for the Albedo Color with the Albedo Texture.",update=update_color_base_mix)
-    Material.msfs_color_sss = bpy.props.FloatVectorProperty(name="SSS Color", subtype='COLOR',min=0.0, max=1.0,size=4, default=[1.0,1.0,1.0,1.0], description = "Use the color picker to set the color of the subsurface scattering.",update=update_color_sss)
+
+    # Main material mode, in accordance with MSFS material shaders:
+    Material.msfs_material_mode = create_material_property_group(
+        EnumProperty(
+            items=(
+                ("NONE", "Disabled", ""),
+                ("msfs_standard", "MSFS Standard", ""),
+                ("msfs_anisotropic", "MSFS Anisotropic", ""),
+                ("msfs_sss", "MSFS Subsurface Scattering", ""),
+                ("msfs_glass", "MSFS Glass", ""),
+                ("msfs_decal", "MSFS Decal", ""),
+                ("msfs_clearcoat", "MSFS Clearcoat", ""),
+                ("msfs_env_occluder", "MSFS Environment Occluder", ""),
+                ("msfs_fake_terrain", "MSFS Fake Terrain", ""),
+                ("msfs_fresnel", "MSFS Fresnel Blending", ""),
+                ("msfs_windshield", "MSFS Windshield", ""),
+                ("msfs_porthole", "MSFS Porthole", ""),
+                ("msfs_parallax", "MSFS Parallax", ""),
+                ("msfs_geo_decal", "MSFS Geo Decal Frosted", ""),
+                ("msfs_hair", "MSFS Hair", ""),
+                ("msfs_invisible", "MSFS Invisible", ""),
+            ),
+            default="NONE",
+            update=switch_msfs_material,
+        ), animated=False
+    )
+
+    # Color blends:
+    Material.msfs_color_albedo_mix = create_material_property_group(
+        FloatVectorProperty(
+            name="Albedo Color",
+            subtype="COLOR",
+            min=0.0,
+            max=1.0,
+            size=4,
+            default=[1.0, 1.0, 1.0, 1.0],
+            description="The color value set here will be mixed in with the albedo value of the material.",
+            update=match_base_color,
+        ), animated=True
+    )
+    Material.msfs_color_emissive_mix = create_material_property_group(
+        FloatVectorProperty(
+            name="Emissive Color",
+            subtype="COLOR",
+            min=0.0,
+            max=1.0,
+            size=4,
+            default=[0.0, 0.0, 0.0, 0.0],
+            description="The color value set here will be mixed in with the emissive value of the material.",
+            update=match_emissive_color,
+        ), animated=True
+    )
+    Material.msfs_color_sss = create_material_property_group(
+        FloatVectorProperty(
+            name="SSS Color",
+            subtype="COLOR",
+            min=0.0,
+            max=1.0,
+            size=4,
+            default=[1.0, 1.0, 1.0, 1.0],
+            description="Use the color picker to set the color of the subsurface scattering.",
+            update=update_color_sss,
+        ), animated=False
+    )
+
     # Windshield
-    Material.msfs_rain_drop_scale = FloatProperty(
-        name="Rain Drop Scale",
-        min=0.0,
-        max=100.0,
-        default=1.0
+    Material.msfs_rain_drop_scale = create_material_property_group(
+        FloatProperty(
+            name="Rain Drop Scale", min=0.0, max=100.0, default=1.0
+        ), animated=False
     )
-    Material.msfs_wiper_1_state = FloatProperty(
-        name="Wiper 1 State",
-        min=0.0,
-        max=1.0,
-        default=0.0
+    Material.msfs_wiper_1_state = create_material_property_group(
+        FloatProperty(
+            name="Wiper 1 State", min=0.0, max=1.0, default=0.0
+        ), animated=False
     )
-    Material.msfs_wiper_2_state = FloatProperty(
-        name="Wiper 2 State",
-        min=0.0,
-        max=1.0,
-        default=0.0
-    )  # The 3DS Max plugin has up to 4 states, but the last 2 aren't visible
-    Material.msfs_wiper_3_state = FloatProperty(
-        name="Wiper 1 State",
-        min=0.0,
-        max=1.0,
-        default=0.0
+    Material.msfs_wiper_2_state = create_material_property_group(
+        FloatProperty(
+            name="Wiper 2 State", min=0.0, max=1.0, default=0.0
+        ), animated=False
+    )  
+    # The 3DS Max plugin has up to 4 states, but the last 2 aren't visible
+    Material.msfs_wiper_3_state = create_material_property_group(
+        FloatProperty(
+            name="Wiper 1 State", min=0.0, max=1.0, default=0.0
+        ), animated=False
     )
-    Material.msfs_wiper_4_state = FloatProperty(
-        name="Wiper 1 State",
-        min=0.0,
-        max=1.0,
-        default=0.0
+    Material.msfs_wiper_4_state = create_material_property_group(
+        FloatProperty(
+            name="Wiper 1 State", min=0.0, max=1.0, default=0.0
+        ), animated= False
     )
 
-    #Glass parameters:
-    Material.msfs_glass_reflection_mask_factor = bpy.props.FloatProperty(name="Reflection mask factor", min=0.0,max=1.0,default=1.0)
-    Material.msfs_glass_deformation_factor = bpy.props.FloatProperty(name = "Deformation factor", min=0.0, max=1.0,default=0.0)
-
-    #Pearl
-    
-
-    Material.msfs_use_pearl_effect = BoolProperty(
-        name="Use Pearl Effect",
-        default=False
+    # Glass parameters:
+    Material.msfs_glass_reflection_mask_factor = create_material_property_group(
+        FloatProperty(
+            name="Reflection mask factor", min=0.0, max=1.0, default=1.0
+        ), animated=False
     )
-    Material.msfs_pearl_shift = FloatProperty(
-        name="Color Shift",
-        min=-999.0,
-        max=999.0,
-        default=0.0
-    )
-    Material.msfs_pearl_range = FloatProperty(
-        name="Color Range",
-        min=-999.0,
-        max=999.0,
-        default=0.0
-    )
-    Material.msfs_pearl_brightness = FloatProperty(
-        name="Color Brightness",
-        min=-1.0,
-        max=1.0,
-        default=0.0
+    Material.msfs_glass_deformation_factor = create_material_property_group(
+        FloatProperty(
+            name="Deformation factor", min=0.0, max=1.0, default=0.0
+        ), animated=False
     )
 
-    #Decal parameters:
-    Material.msfs_decal_blend_factor_color = bpy.props.FloatProperty(name="Color", min=0.0,max=1.0,default=1.0)
-    Material.msfs_decal_blend_factor_metal = bpy.props.FloatProperty(name="Metal", min=0.0,max=1.0,default=1.0)
-    Material.msfs_decal_blend_factor_normal = bpy.props.FloatProperty(name="Normal", min=0.0,max=1.0,default=1.0)
-    Material.msfs_decal_blend_factor_roughness = bpy.props.FloatProperty(name="Roughness", min=0.0,max=1.0,default=1.0)
-    Material.msfs_decal_blend_factor_occlusion = bpy.props.FloatProperty(name="Occlusion", min=0.0,max=1.0,default=1.0)
-    Material.msfs_decal_blend_factor_emissive = bpy.props.FloatProperty(name="Emissive", min=0.0,max=1.0,default=1.0)
+    # Pearl
 
-    #Fresnel parameters:
-    Material.msfs_fresnel_factor = bpy.props.FloatProperty(name="Fresnel factor", min=0.0,max=1.0,default=1.0)
-    Material.msfs_fresnel_opacity_bias = bpy.props.FloatProperty(name="Fresnel opacity bias", min=0.0,max=1.0,default=1.0)
+    Material.msfs_use_pearl_effect = create_material_property_group(
+        BoolProperty(
+            name="Use Pearl Effect", default=False
+        ), animated=False
+    )
+    Material.msfs_pearl_shift = create_material_property_group(
+        FloatProperty(
+            name="Color Shift", min=-999.0, max=999.0, default=0.0
+        ), animated=False
+    )
+    Material.msfs_pearl_range = create_material_property_group(
+        FloatProperty(
+            name="Color Range", min=-999.0, max=999.0, default=0.0
+        ), animated=False
+    )
+    Material.msfs_pearl_brightness = create_material_property_group(
+        FloatProperty(
+            name="Color Brightness", min=-1.0, max=1.0, default=0.0
+        ), animated=False
+    )
 
-    #Parallax parameters:
-    Material.msfs_parallax_scale = bpy.props.FloatProperty(name="Scale", min=0.0,max=1.0,default=0.0)
-    Material.msfs_parallax_room_size_x = bpy.props.FloatProperty(name="X", min=0.0,default=0.5)
-    Material.msfs_parallax_room_size_y = bpy.props.FloatProperty(name="Y", min=0.0,default=0.5)
-    Material.msfs_parallax_room_number = bpy.props.FloatProperty(name="Rm number XY", min=0.0,default=1.0)
-    Material.msfs_parallax_corridor = bpy.props.BoolProperty(name="Corridor", default=False)
+    # Decal parameters:
+    Material.msfs_decal_blend_factor_color = create_material_property_group(
+        FloatProperty(
+            name="Color", min=0.0, max=1.0, default=1.0
+        ), animated=False
+    )
+    Material.msfs_decal_blend_factor_metal = create_material_property_group(
+        FloatProperty(
+            name="Metal", min=0.0, max=1.0, default=1.0
+        ), animated=False
+    )
+    Material.msfs_decal_blend_factor_normal = create_material_property_group(
+        FloatProperty(
+            name="Normal", min=0.0, max=1.0, default=1.0
+        ), animated=False
+    )
+    Material.msfs_decal_blend_factor_roughness = create_material_property_group(
+        FloatProperty(
+            name="Roughness", min=0.0, max=1.0, default=1.0
+        ), animated=False
+    )
+    Material.msfs_decal_blend_factor_occlusion = create_material_property_group(
+        FloatProperty(
+            name="Occlusion", min=0.0, max=1.0, default=1.0
+        ), animated=False
+    )
+    Material.msfs_decal_blend_factor_emissive = create_material_property_group(
+        FloatProperty(
+            name="Emissive", min=0.0, max=1.0, default=1.0
+        ), animated=False
+    )
 
-    #Geo Decal Frosted parameters:
-    Material.msfs_geo_decal_blend_factor_color = bpy.props.FloatProperty(name="Color", min=0.0,max=1.0,default=1.0)
-    Material.msfs_geo_decal_blend_factor_metal = bpy.props.FloatProperty(name="Metal", min=0.0,max=1.0,default=1.0)
-    Material.msfs_geo_decal_blend_factor_normal = bpy.props.FloatProperty(name="Normal", min=0.0,max=1.0,default=1.0)
-    Material.msfs_geo_decal_blend_factor_roughness = bpy.props.FloatProperty(name="Roughness", min=0.0,max=1.0,default=1.0)
-    Material.msfs_geo_decal_blend_factor_blast_sys = bpy.props.FloatProperty(name="Blast Sys.", min=0.0,max=1.0,default=1.0)
-    Material.msfs_geo_decal_blend_factor_melt_sys = bpy.props.FloatProperty(name="Melt Sys", min=0.0,max=1.0,default=1.0)
+    # Fresnel parameters:
+    Material.msfs_fresnel_factor = create_material_property_group(
+        FloatProperty(
+            name="Fresnel factor", min=0.0, max=1.0, default=1.0
+        ), animated=False
+    )
+    Material.msfs_fresnel_opacity_bias = create_material_property_group(
+        FloatProperty(
+            name="Fresnel opacity bias", min=0.0, max=1.0, default=1.0
+        ), animated=False
+    )
 
-    #Textures:
+    # Parallax parameters:
+    Material.msfs_parallax_scale = create_material_property_group(
+        FloatProperty(
+            name="Scale", min=0.0, max=1.0, default=0.0
+        ), animated=False
+    )
+    Material.msfs_parallax_room_size_x = create_material_property_group(
+        FloatProperty(
+            name="X", min=0.0, default=0.5
+        ), animated=False
+    )
+    Material.msfs_parallax_room_size_y = create_material_property_group(
+        FloatProperty(
+            name="Y", min=0.0, default=0.5
+        ), animated=False
+    )
+    Material.msfs_parallax_room_number = create_material_property_group(
+        FloatProperty(
+            name="Rm number XY", min=0.0, default=1.0
+        ), animated=False
+    )
+    Material.msfs_parallax_corridor = create_material_property_group(
+        BoolProperty(
+            name="Corridor", default=False
+        ), animated=False
+    )
+
+    # Geo Decal Frosted parameters:
+    Material.msfs_geo_decal_blend_factor_color = create_material_property_group(
+        FloatProperty(
+            name="Color", min=0.0, max=1.0, default=1.0
+        ), animated=False
+    )
+    Material.msfs_geo_decal_blend_factor_metal = create_material_property_group(
+        FloatProperty(
+            name="Metal", min=0.0, max=1.0, default=1.0
+        ), animated=False
+    )
+    Material.msfs_geo_decal_blend_factor_normal = create_material_property_group(
+        FloatProperty(
+            name="Normal", min=0.0, max=1.0, default=1.0
+        ), animated=False
+    )
+    Material.msfs_geo_decal_blend_factor_roughness = create_material_property_group(
+        FloatProperty(
+            name="Roughness", min=0.0, max=1.0, default=1.0
+        ), animated=False
+    )
+    Material.msfs_geo_decal_blend_factor_blast_sys = create_material_property_group(
+        FloatProperty(
+            name="Blast Sys.", min=0.0, max=1.0, default=1.0
+        ), animated=False
+    )
+    Material.msfs_geo_decal_blend_factor_melt_sys = create_material_property_group(
+        FloatProperty(
+            name="Melt Sys", min=0.0, max=1.0, default=1.0
+        ), animated=False
+    )
+
+    # Textures:
     Material.msfs_albedo_texture = PointerProperty(type = Image, name = "Albedo map", update = match_base_color_tex)
     Material.msfs_metallic_texture = PointerProperty(type = Image, name = "Metallic map", update = match_comp_tex)
     Material.msfs_normal_texture = PointerProperty(type = Image, name = "Normal map", update = match_normal_tex)
@@ -495,71 +630,168 @@ class MSFS_LI_material():
     Material.msfs_behind_glass_texture = PointerProperty(type = Image, name = "Behind glass Albedo map", update = match_behind_glass)
     Material.msfs_wiper_mask_texture = PointerProperty(type = Image, name = "Wiper mask (RG)", update = match_wiper_mask)
 
-    #Alpha mode:
-    Material.msfs_blend_mode = bpy.props.EnumProperty(name="Blend mode",items=(('OPAQUE',"Opaque","Creates a fully non-transparent material."),
-                                                                               ('MASKED',"Masked","This blend mode uses the alpha map to mask off parts of the material, but only if the alpha value exceeds the value set in the alpha cutoff parameter."),
-                                                                               ('BLEND',"Blend","This blend mode uses the alpha map to gradually blend in the material. Use this for materials like glass."),
-                                                                               ('DITHER',"Dither","Weird blend mode. But works well for hair. No visible effect in Blender."),), 
-                                                                               default='OPAQUE',update=switch_msfs_blendmode)
-    
-    #Render parameters:
-    Material.msfs_draw_order = bpy.props.IntProperty(name="Draw order",default = 0, min = 0)
-    Material.msfs_no_cast_shadow = bpy.props.BoolProperty(name="No cast shadow",default=False)
-    Material.msfs_double_sided = bpy.props.BoolProperty(name="Double sided",default=False,update=update_double_sided)
-    Material.msfs_responsive_aa = bpy.props.BoolProperty(name="Responsive AA", default=False,description="")
-    Material.msfs_day_night_cycle = bpy.props.BoolProperty(name="Day/Night cycle", default=False)
-
-    #Gameplay parameters:
-    Material.msfs_collision_material = bpy.props.BoolProperty(name="Collision material",default=False)
-    Material.msfs_road_material = bpy.props.BoolProperty(name="Road material",default=False)
-
-    #UV options:
-    
-    Material.msfs_uv_offset_u = FloatProperty(
-        name="U",
-        min=-10.0,
-        max=10.0,
-        default=0.0
+    # Alpha mode:
+    Material.msfs_blend_mode = create_material_property_group(
+        EnumProperty(
+            name="Blend mode",
+            items=(
+                ("OPAQUE", "Opaque", "Creates a fully non-transparent material."),
+                (
+                    "MASKED",
+                    "Masked",
+                    "This blend mode uses the alpha map to mask off parts of the material, but only if the alpha value exceeds the value set in the alpha cutoff parameter.",
+                ),
+                (
+                    "BLEND",
+                    "Blend",
+                    "This blend mode uses the alpha map to gradually blend in the material. Use this for materials like glass.",
+                ),
+                (
+                    "DITHER",
+                    "Dither",
+                    "Weird blend mode. But works well for hair. No visible effect in Blender.",
+                ),
+            ),
+            default="OPAQUE",
+            update=switch_msfs_blendmode,
+        ), animated=False
     )
-    Material.msfs_uv_offset_v = FloatProperty(
-        name="V",
-        min=-10.0,
-        max=10.0,
-        default=0.0
-    )
-    Material.msfs_uv_tiling_u = FloatProperty(
-        name="U",
-        min=-10.0,
-        max=10.0,
-        default=1.0
-    )
-    Material.msfs_uv_tiling_v = FloatProperty(
-        name="V",
-        min=-10.0,
-        max=10.0,
-        default=1.0
-    )
-    Material.msfs_uv_rotation = FloatProperty(
-        name="UV Rotation",
-        min=-360.0,
-        max=360.0,
-        default=0.0
-    )
-    Material.msfs_ao_use_uv2 = bpy.props.BoolProperty(name="AO use UV2",default=False)
-    Material.msfs_uv_clamp_x = bpy.props.BoolProperty(name="X",default=False)
-    Material.msfs_uv_clamp_y = bpy.props.BoolProperty(name="Y",default=False)
-    Material.msfs_uv_clamp_z = bpy.props.BoolProperty(name="Z",default=False)
 
-    #Material parameters
-    Material.msfs_roughness_scale = bpy.props.FloatProperty(name="Roughness scale",min=0,max=1,default=1, update = match_roughness_scale)
-    Material.msfs_metallic_scale = bpy.props.FloatProperty(name="Metallic scale",min=0,max=1,default=1, update = match_metallic_scale)
-    Material.msfs_emissive_scale = bpy.props.FloatProperty(name="Emissive scale",min=0,max=1,default=1, update = match_emissive_scale)
-    Material.msfs_normal_scale = bpy.props.FloatProperty(name="Normal scale",min=0,default=1,update=match_normal_scale)
-    Material.msfs_alpha_cutoff = bpy.props.FloatProperty(name="Alpha cutoff",min=0,max=1,default=0.1,update=match_alpha_cutoff)
-    Material.msfs_detail_uv_scale = bpy.props.FloatProperty(name="Detail UV scale",min=0,default=1,update=match_detail_uv)
-    Material.msfs_detail_uv_offset_x = bpy.props.FloatProperty(name="X",min=-1,max=1,default=0,update=match_detail_uv)
-    Material.msfs_detail_uv_offset_y = bpy.props.FloatProperty(name="Y",min=-1,max=1,default=0,update=match_detail_uv)
-    Material.msfs_detail_normal_scale = bpy.props.FloatProperty(name="Detail normal scale",min=0,max=1,default=1, update = match_detail_uv)
-    Material.msfs_blend_threshold = bpy.props.FloatProperty(name="Blend threshold",min=0,max=1,default=0.1)
+    # Render parameters:
+    Material.msfs_draw_order = create_material_property_group(
+        IntProperty(
+            name="Draw order", default=0, min=0
+        ), animated=False
+    )
+    Material.msfs_no_cast_shadow = create_material_property_group(
+        BoolProperty(
+            name="No cast shadow", default=False
+        ), animated=False
+    )
+    Material.msfs_double_sided = create_material_property_group(
+        BoolProperty(
+            name="Double sided", default=False, update=update_double_sided
+        ), animated=False
+    )
+    Material.msfs_responsive_aa = create_material_property_group(
+        BoolProperty(
+            name="Responsive AA", default=False, description=""
+        ), animated=False
+    )
+    Material.msfs_day_night_cycle = create_material_property_group(
+        BoolProperty(
+            name="Day/Night cycle", default=False
+        ), animated=False
+    )
 
+    # Gameplay parameters:
+    Material.msfs_collision_material = create_material_property_group(
+        BoolProperty(
+            name="Collision material", default=False
+        ), animated=False
+    )
+    Material.msfs_road_material = create_material_property_group(
+        BoolProperty(
+            name="Road material", default=False
+        ), animated=False
+    )
 
+    # UV options:
+
+    Material.msfs_uv_offset_u = create_material_property_group(
+        FloatProperty(
+            name="U", min=-10.0, max=10.0, default=0.0
+        ), animated=True
+    )
+    Material.msfs_uv_offset_v = create_material_property_group(
+        FloatProperty(
+            name="V", min=-10.0, max=10.0, default=0.0
+        ), animated=True
+    )
+    Material.msfs_uv_tiling_u = create_material_property_group(
+        FloatProperty(
+            name="U", min=-10.0, max=10.0, default=1.0
+        ), animated=True
+    )
+    Material.msfs_uv_tiling_v = create_material_property_group(
+        FloatProperty(
+            name="V", min=-10.0, max=10.0, default=1.0
+        ), animated=True
+    )
+    Material.msfs_uv_rotation = create_material_property_group(
+        FloatProperty(
+            name="UV Rotation", min=-360.0, max=360.0, default=0.0
+        ), animated=True
+    )
+    Material.msfs_ao_use_uv2 = create_material_property_group(
+        BoolProperty(
+            name="AO use UV2", default=False
+        ), animated=False
+    )
+    Material.msfs_uv_clamp_x = create_material_property_group(
+        BoolProperty(
+            name="X", default=False
+        ), animated=False
+    )
+    Material.msfs_uv_clamp_y = create_material_property_group(
+        BoolProperty(
+            name="Y", default=False
+        ), animated=False
+    )
+    Material.msfs_uv_clamp_z = create_material_property_group(
+        BoolProperty(
+            name="Z", default=False
+        ), animated=False
+    )
+
+    # Material parameters
+    Material.msfs_roughness_scale = create_material_property_group(
+        FloatProperty(
+            name="Roughness scale", min=0, max=1, default=1, update=match_roughness_scale
+        ), animated=True
+    )
+    Material.msfs_metallic_scale = create_material_property_group(
+        FloatProperty(
+            name="Metallic scale", min=0, max=1, default=1, update=match_metallic_scale
+        ), animated=True
+    )
+    Material.msfs_emissive_scale = create_material_property_group(
+        FloatProperty(
+            name="Emissive scale", min=0, max=1, default=1, update=match_emissive_scale
+        ), animated=False
+    )
+    Material.msfs_normal_scale = create_material_property_group(
+        FloatProperty(
+            name="Normal scale", min=0, default=1, update=match_normal_scale
+        ), animated=False
+    )
+    Material.msfs_alpha_cutoff = create_material_property_group(
+        FloatProperty(
+            name="Alpha cutoff", min=0, max=1, default=0.1, update=match_alpha_cutoff
+        ), animated=False
+    )
+    Material.msfs_detail_uv_scale = create_material_property_group(
+        FloatProperty(
+            name="Detail UV scale", min=0, default=1, update=match_detail_uv
+        ), animated=False
+    )
+    Material.msfs_detail_uv_offset_x = create_material_property_group(
+        FloatProperty(
+            name="X", min=-1, max=1, default=0, update=match_detail_uv
+        ), animated=False
+    )
+    Material.msfs_detail_uv_offset_y = create_material_property_group(
+        FloatProperty(
+            name="Y", min=-1, max=1, default=0, update=match_detail_uv
+        ), animated=False
+    )
+    Material.msfs_detail_normal_scale = create_material_property_group(
+        FloatProperty(
+            name="Detail normal scale", min=0, max=1, default=1, update=match_detail_uv
+        ), animated=False
+    )
+    Material.msfs_blend_threshold = create_material_property_group(
+        FloatProperty(
+            name="Blend threshold", min=0, max=1, default=0.1
+        ), animated=False
+    )

--- a/addons/io_scene_gltf2_msfs/io/msfs_export.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_export.py
@@ -20,6 +20,7 @@ import bpy
 from .msfs_light import MSFSLight
 from .msfs_gizmo import MSFSGizmo
 from .msfs_material import MSFSMaterial
+from .msfs_material_animation import MSFSMaterialAnimation
 
 class Export:
     def gather_asset_hook(self, gltf2_asset, export_settings):
@@ -34,7 +35,10 @@ class Export:
 
     def gather_gltf_hook(self, gltf2_plan, export_settings):
         for i, image in enumerate(gltf2_plan.images):
-            image.uri =os.path.basename(image.uri)
+            image.uri = os.path.basename(image.uri)
+
+        for animation in gltf2_plan.animations:
+            MSFSMaterialAnimation.finalize_animation(animation, gltf2_plan)
 
     def gather_node_hook(self, gltf2_object, blender_object, export_settings):
         if self.properties.enabled == True:
@@ -77,3 +81,9 @@ class Export:
                     gltf2_material.extras = {}
 
                 MSFSMaterial.export(gltf2_material, blender_material, export_settings)
+
+    def gather_actions_hook(self, blender_object, blender_actions, blender_tracks, action_on_type, export_settings):
+        MSFSMaterialAnimation.gather_actions(blender_object, blender_actions, blender_tracks, action_on_type, export_settings)
+
+    def gather_animation_channel_hook(self, gltf2_animation_channel, channels, blender_object, bake_bone, bake_channel, bake_range_start, bake_range_end, action_name, export_settings):
+        MSFSMaterialAnimation.replace_channel_target(gltf2_animation_channel, channels, blender_object, action_name)

--- a/addons/io_scene_gltf2_msfs/io/msfs_export.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_export.py
@@ -38,7 +38,7 @@ class Export:
             image.uri = os.path.basename(image.uri)
 
         for animation in gltf2_plan.animations:
-            MSFSMaterialAnimation.finalize_animation(animation, gltf2_plan)
+            MSFSMaterialAnimation.finalize_target(animation, gltf2_plan)
 
     def gather_node_hook(self, gltf2_object, blender_object, export_settings):
         if self.properties.enabled == True:
@@ -87,3 +87,6 @@ class Export:
 
     def gather_animation_channel_hook(self, gltf2_animation_channel, channels, blender_object, bake_bone, bake_channel, bake_range_start, bake_range_end, action_name, export_settings):
         MSFSMaterialAnimation.replace_channel_target(gltf2_animation_channel, channels, blender_object, action_name)
+
+    def gather_animation_hook(self, gltf2_animation, blender_action, blender_object, export_settings):
+        MSFSMaterialAnimation.finalize_animation(gltf2_animation)

--- a/addons/io_scene_gltf2_msfs/io/msfs_material.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_material.py
@@ -276,18 +276,21 @@ class MSFSMaterial:
 
         # UV Options
         if blender_material.msfs_show_ao_use_uv2 or blender_material.msfs_show_uv_clamp:
-            if (blender_material.msfs_ao_use_uv2.value or blender_material.msfs_uv_clamp_x.value or \
-                    blender_material.msfs_uv_clamp_y.value or blender_material.msfs_uv_clamp_z.value):
-                gltf2_material.extensions["ASOBO_material_UV_options"] = Extension(
-                    name="ASOBO_material_UV_options",
-                    extension={
-                        "AOUseUV2": blender_material.msfs_ao_use_uv2.value,
-                        "clampUVX": blender_material.msfs_uv_clamp_x.value,
-                        "clampUVY": blender_material.msfs_uv_clamp_y.value,
-                        "clampUVZ": blender_material.msfs_uv_clamp_z.value
-                    },
-                    required=False
-                )
+            gltf2_material.extensions["ASOBO_material_UV_options"] = Extension(
+                name="ASOBO_material_UV_options",
+                extension={
+                    "AOUseUV2": blender_material.msfs_ao_use_uv2.value,
+                    "clampUVX": blender_material.msfs_uv_clamp_x.value,
+                    "clampUVY": blender_material.msfs_uv_clamp_y.value,
+                    "clampUVZ": blender_material.msfs_uv_clamp_z.value,
+                    "UVOffsetU": blender_material.msfs_uv_offset_u.value,
+                    "UVOffsetV": blender_material.msfs_uv_offset_v.value,
+                    "UVTilingU": blender_material.msfs_uv_tiling_u.value,
+                    "UVTilingV": blender_material.msfs_uv_tiling_v.value,
+                    "UVRotation": blender_material.msfs_uv_rotation.value
+                },
+                required=False
+            )
 
         # Detail maps
         if (blender_material.msfs_show_detail_albedo or blender_material.msfs_show_detail_metallic or  \

--- a/addons/io_scene_gltf2_msfs/io/msfs_material.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_material.py
@@ -55,7 +55,7 @@ class MSFSMaterial:
     def export(gltf2_material, blender_material, export_settings):
         # Set material type and related properties
         # Anisotropic
-        if blender_material.msfs_material_mode == "msfs_anisotropic":
+        if blender_material.msfs_material_mode.value == "msfs_anisotropic":
             gltf2_material.extensions["ASOBO_material_anisotropic"] = Extension(
                 name="ASOBO_material_anisotropic",
                 extension={
@@ -65,54 +65,54 @@ class MSFSMaterial:
             )
 
         # SSS, Hair
-        elif blender_material.msfs_material_mode in ["msfs_sss", "msfs_hair"]:
+        elif blender_material.msfs_material_mode.value in ["msfs_sss", "msfs_hair"]:
             gltf2_material.extensions["ASOBO_material_SSS"] = Extension(
                 name="ASOBO_material_SSS",
                 extension={
-                    "SSSColor": list(blender_material.msfs_color_sss)
+                    "SSSColor": list(blender_material.msfs_color_sss.value)
                 },
                 required=False
             )
 
         # Hair
-        elif blender_material.msfs_material_mode == "msfs_glass":
+        elif blender_material.msfs_material_mode.value == "msfs_glass":
             gltf2_material.extensions["ASOBO_material_glass"] = Extension(
                 name="ASOBO_material_glass",
                 extension={
-                    "glassReflectionMaskFactor": blender_material.msfs_glass_reflection_mask_factor,
-                    "glassDeformationFactor": blender_material.msfs_glass_deformation_factor
+                    "glassReflectionMaskFactor": blender_material.msfs_glass_reflection_mask_factor.value,
+                    "glassDeformationFactor": blender_material.msfs_glass_deformation_factor.value
                 },
                 required=False
             )
 
         # Decal
-        elif blender_material.msfs_material_mode == "msfs_decal":
+        elif blender_material.msfs_material_mode.value == "msfs_decal":
             gltf2_material.extensions["ASOBO_material_blend_gbuffer"] = Extension(
                 name="ASOBO_material_blend_gbuffer",
                 extension={
                     "enabled": True,
-                    "baseColorBlendFactor": blender_material.msfs_decal_blend_factor_color,
-                    "metallicBlendFactor": blender_material.msfs_decal_blend_factor_metal,
-                    "roughnessBlendFactor": blender_material.msfs_decal_blend_factor_roughness,
-                    "normalBlendFactor": blender_material.msfs_decal_blend_factor_normal,
-                    "emissiveBlendFactor": blender_material.msfs_decal_blend_factor_emissive,
-                    "occlusionBlendFactor": blender_material.msfs_decal_blend_factor_occlusion,
+                    "baseColorBlendFactor": blender_material.msfs_decal_blend_factor_color.value,
+                    "metallicBlendFactor": blender_material.msfs_decal_blend_factor_metal.value,
+                    "roughnessBlendFactor": blender_material.msfs_decal_blend_factor_roughness.value,
+                    "normalBlendFactor": blender_material.msfs_decal_blend_factor_normal.value,
+                    "emissiveBlendFactor": blender_material.msfs_decal_blend_factor_emissive.value,
+                    "occlusionBlendFactor": blender_material.msfs_decal_blend_factor_occlusion.value,
                 },
                 required=False
             )
 
         # Clearcoat
-        elif blender_material.msfs_material_mode == "msfs_clearcoat":
+        elif blender_material.msfs_material_mode.value == "msfs_clearcoat":
             gltf2_material.extensions["ASOBO_material_clear_coat"] = Extension(
                 name="ASOBO_material_clear_coat",
                 extension={
-                    "dirtTexture": MSFSMaterial.export_image(blender_material, blender_material.msfs_clearcoat_texture, export_settings)
+                    "dirtTexture": MSFSMaterial.export_image(blender_material, blender_material.msfs_clearcoat_texture.value, export_settings)
                 },
                 required=False
             )
 
         # Environment occluder
-        elif blender_material.msfs_material_mode == "msfs_env_occluder":
+        elif blender_material.msfs_material_mode.value == "msfs_env_occluder":
             gltf2_material.extensions["ASOBO_material_environment_occluder"] = Extension(
                 name="ASOBO_material_environment_occluder",
                 extension={
@@ -122,7 +122,7 @@ class MSFSMaterial:
             )
 
         # Fake terrain
-        elif blender_material.msfs_material_mode == "msfs_fake_terrain":
+        elif blender_material.msfs_material_mode.value == "msfs_fake_terrain":
             gltf2_material.extensions["ASOBO_material_fake_terrain"] = Extension(
                 name="ASOBO_material_fake_terrain",
                 extension={
@@ -132,27 +132,27 @@ class MSFSMaterial:
             )
 
         # Fresnel
-        elif blender_material.msfs_material_mode == "msfs_fresnel":
+        elif blender_material.msfs_material_mode.value == "msfs_fresnel":
             gltf2_material.extensions["ASOBO_material_fresnel_fade"] = Extension(
                 name="ASOBO_material_fresnel_fade",
                 extension={
-                    "fresnelFactor": blender_material.msfs_fresnel_factor,
-                    "fresnelOpacityOffset": blender_material.msfs_fresnel_opacity_bias
+                    "fresnelFactor": blender_material.msfs_fresnel_factor.value,
+                    "fresnelOpacityOffset": blender_material.msfs_fresnel_opacity_bias.value
                 },
                 required=False
             )
 
         # Windshield
-        elif blender_material.msfs_material_mode == "msfs_windshield":
-            if blender_material.msfs_rain_drop_scale > 0:
+        elif blender_material.msfs_material_mode.value == "msfs_windshield":
+            if blender_material.msfs_rain_drop_scale.value > 0:
                 gltf2_material.extensions["ASOBO_material_windshield_v2"] = Extension(
                     name="ASOBO_material_windshield_v2",
                     extension={
-                        "rainDropScale": blender_material.msfs_rain_drop_scale,
-                        "wiper1State": blender_material.msfs_wiper_1_state,
-                        "wiper2State": blender_material.msfs_wiper_2_state,
-                        "wiper3State": blender_material.msfs_wiper_3_state,
-                        "wiper4State": blender_material.msfs_wiper_4_state
+                        "rainDropScale": blender_material.msfs_rain_drop_scale.value,
+                        "wiper1State": blender_material.msfs_wiper_1_state.value,
+                        "wiper2State": blender_material.msfs_wiper_2_state.value,
+                        "wiper3State": blender_material.msfs_wiper_3_state.value,
+                        "wiper4State": blender_material.msfs_wiper_4_state.value
                     },
                     required=False
                 )
@@ -160,42 +160,42 @@ class MSFSMaterial:
             gltf2_material.extras["ASOBO_material_code"] = "Windshield"
 
         # Porthole
-        elif blender_material.msfs_material_mode == "msfs_porthole":
+        elif blender_material.msfs_material_mode.value == "msfs_porthole":
             gltf2_material.extras["ASOBO_material_code"] = "Porthole"
 
         # Parallax
-        elif blender_material.msfs_material_mode == "msfs_parallax":
+        elif blender_material.msfs_material_mode.value == "msfs_parallax":
             gltf2_material.extensions["ASOBO_material_parallax_window"] = Extension(
                 name="ASOBO_material_parallax_window",
                 extension={
-                    "parallaxScale": blender_material.msfs_parallax_scale,
-                    "roomSizeXScale": blender_material.msfs_parallax_room_size_x,
-                    "roomSizeYScale": blender_material.msfs_parallax_room_size_y,
-                    "roomNumberXY": blender_material.msfs_parallax_room_number,
-                    "corridor": blender_material.msfs_parallax_corridor,
+                    "parallaxScale": blender_material.msfs_parallax_scale.value,
+                    "roomSizeXScale": blender_material.msfs_parallax_room_size_x.value,
+                    "roomSizeYScale": blender_material.msfs_parallax_room_size_y.value,
+                    "roomNumberXY": blender_material.msfs_parallax_room_number.value,
+                    "corridor": blender_material.msfs_parallax_corridor.value,
                     "behindWindowMapTexture": MSFSMaterial.export_image(blender_material, blender_material.msfs_behind_glass_texture, export_settings)
                 },
                 required=False
             )
 
         # Geo decal
-        elif blender_material.msfs_material_mode == "msfs_geo_decal":
+        elif blender_material.msfs_material_mode.value == "msfs_geo_decal":
             gltf2_material.extensions["ASOBO_material_blend_gbuffer"] = Extension(
                 name="ASOBO_material_blend_gbuffer",
                 extension={
-                    "baseColorBlendFactor": blender_material.msfs_geo_decal_blend_factor_color,
-                    "metallicBlendFactor": blender_material.msfs_geo_decal_blend_factor_metal,
-                    "roughnessBlendFactor": blender_material.msfs_geo_decal_blend_factor_roughness,
-                    "normalBlendFactor": blender_material.msfs_geo_decal_blend_factor_normal,
-                    "emissiveBlendFactor": blender_material.msfs_geo_decal_blend_factor_melt_sys,
-                    "occlusionBlendFactor": blender_material.msfs_geo_decal_blend_factor_blast_sys,
+                    "baseColorBlendFactor": blender_material.msfs_geo_decal_blend_factor_color.value,
+                    "metallicBlendFactor": blender_material.msfs_geo_decal_blend_factor_metal.value,
+                    "roughnessBlendFactor": blender_material.msfs_geo_decal_blend_factor_roughness.value,
+                    "normalBlendFactor": blender_material.msfs_geo_decal_blend_factor_normal.value,
+                    "emissiveBlendFactor": blender_material.msfs_geo_decal_blend_factor_melt_sys.value,
+                    "occlusionBlendFactor": blender_material.msfs_geo_decal_blend_factor_blast_sys.value,
                 },
                 required=False
             )
             gltf2_material.extras["ASOBO_material_code"] = "GeoDecalFrosted"
 
         # Invisible
-        elif blender_material.msfs_material_mode == "msfs_invisible":
+        elif blender_material.msfs_material_mode.value == "msfs_invisible":
             gltf2_material.extensions["ASOBO_material_invisible"] = Extension(
                 name="ASOBO_material_invisible",
                 extension={
@@ -206,7 +206,7 @@ class MSFSMaterial:
 
 
         # Set blendmode
-        if blender_material.msfs_show_blend_mode and blender_material.msfs_blend_mode == 'DITHER':
+        if blender_material.msfs_show_blend_mode and blender_material.msfs_blend_mode.value == 'DITHER':
             gltf2_material.extensions["ASOBO_material_alphamode_dither"] = Extension(
                 name="ASOBO_material_alphamode_dither",
                 extension={
@@ -218,9 +218,9 @@ class MSFSMaterial:
         # Set Asobo tags
         if blender_material.msfs_show_road_material or blender_material.msfs_show_collision_material:
             tags = []
-            if blender_material.msfs_road_material == True:
+            if blender_material.msfs_road_material.value == True:
                 tags.append("Road")
-            if blender_material.msfs_collision_material == True:
+            if blender_material.msfs_collision_material.value == True:
                 tags.append("Collision")
 
             if tags:
@@ -233,7 +233,7 @@ class MSFSMaterial:
                 )
 
         # Day/Night cycle
-        if blender_material.msfs_show_day_night_cycle and blender_material.msfs_day_night_cycle:
+        if blender_material.msfs_show_day_night_cycle and blender_material.msfs_day_night_cycle.value:
             gltf2_material.extensions["ASOBO_material_day_night_switch"] = Extension(
                 name="ASOBO_material_day_night_switch",
                 extension={
@@ -243,48 +243,48 @@ class MSFSMaterial:
             )
 
         # Draw order
-        if blender_material.msfs_show_draworder and blender_material.msfs_draw_order > 0:
+        if blender_material.msfs_show_draworder and blender_material.msfs_draw_order.value > 0:
             gltf2_material.extensions["ASOBO_material_draw_order"] = Extension(
                 name="ASOBO_material_draw_order",
                 extension={
-                    "drawOrderOffset": blender_material.msfs_draw_order
+                    "drawOrderOffset": blender_material.msfs_draw_order.value
                 },
                 required=False
             )
 
         # Cast shadow
-        if blender_material.msfs_show_no_cast_shadow and blender_material.msfs_no_cast_shadow:
+        if blender_material.msfs_show_no_cast_shadow and blender_material.msfs_no_cast_shadow.value:
             gltf2_material.extensions["ASOBO_material_shadow_options"] = Extension(
                 name="ASOBO_material_shadow_options",
                 extension={
-                    "noCastShadow": blender_material.msfs_no_cast_shadow
+                    "noCastShadow": blender_material.msfs_no_cast_shadow.value
                 },
                 required=False
             )
 
         # Pearlescent
-        if blender_material.msfs_show_pearl and blender_material.msfs_use_pearl_effect:
+        if blender_material.msfs_show_pearl and blender_material.msfs_use_pearl_effect.value:
             gltf2_material.extensions["ASOBO_material_pearlescent"] = Extension(
                 name="ASOBO_material_pearlescent",
                 extension={
-                    "pearlShift": blender_material.msfs_pearl_shift,
-                    "pearlRange": blender_material.msfs_pearl_range,
-                    "pearlBrightness": blender_material.msfs_pearl_brightness
+                    "pearlShift": blender_material.msfs_pearl_shift.value,
+                    "pearlRange": blender_material.msfs_pearl_range.value,
+                    "pearlBrightness": blender_material.msfs_pearl_brightness.value
                 },
                 required=False
             )
 
         # UV Options
         if blender_material.msfs_show_ao_use_uv2 or blender_material.msfs_show_uv_clamp:
-            if (blender_material.msfs_ao_use_uv2 or blender_material.msfs_uv_clamp_x or \
-                    blender_material.msfs_uv_clamp_y or blender_material.msfs_uv_clamp_z):
+            if (blender_material.msfs_ao_use_uv2.value or blender_material.msfs_uv_clamp_x.value or \
+                    blender_material.msfs_uv_clamp_y.value or blender_material.msfs_uv_clamp_z.value):
                 gltf2_material.extensions["ASOBO_material_UV_options"] = Extension(
                     name="ASOBO_material_UV_options",
                     extension={
-                        "AOUseUV2": blender_material.msfs_ao_use_uv2,
-                        "clampUVX": blender_material.msfs_uv_clamp_x,
-                        "clampUVY": blender_material.msfs_uv_clamp_y,
-                        "clampUVZ": blender_material.msfs_uv_clamp_z
+                        "AOUseUV2": blender_material.msfs_ao_use_uv2.value,
+                        "clampUVX": blender_material.msfs_uv_clamp_x.value,
+                        "clampUVY": blender_material.msfs_uv_clamp_y.value,
+                        "clampUVZ": blender_material.msfs_uv_clamp_z.value
                     },
                     required=False
                 )
@@ -298,9 +298,9 @@ class MSFSMaterial:
                         "detailColorTexture": MSFSMaterial.export_image(blender_material, blender_material.msfs_detail_albedo_texture, export_settings),
                         "detailMetalRoughAOTexture": MSFSMaterial.export_image(blender_material, blender_material.msfs_detail_metallic_texture, export_settings),
                         "detailNormalTexture": MSFSMaterial.export_image(blender_material, blender_material.msfs_detail_normal_texture, export_settings),
-                        "UVScale": blender_material.msfs_detail_uv_scale,
-                        "UVOffset": (blender_material.msfs_detail_uv_offset_x, blender_material.msfs_detail_uv_offset_y),
-                        "blendThreshold": blender_material.msfs_blend_threshold
+                        "UVScale": blender_material.msfs_detail_uv_scale.value,
+                        "UVOffset": (blender_material.msfs_detail_uv_offset_x.value, blender_material.msfs_detail_uv_offset_y.value),
+                        "blendThreshold": blender_material.msfs_blend_threshold.value
                     },
                     required=False
                 )

--- a/addons/io_scene_gltf2_msfs/io/msfs_material_animation.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_material_animation.py
@@ -1,5 +1,5 @@
 # glTF-Blender-IO-MSFS
-# Copyright (C) 2020-2021 The glTF-Blender-IO-MSFS authors
+# Copyright (C) 2022 The glTF-Blender-IO-MSFS authors
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,10 +28,6 @@ class MSFSMaterialAnimation:
 
     def __new__(cls, *args, **kwargs):
         raise RuntimeError("%s should not be instantiated" % cls)
-
-    @staticmethod
-    def create():
-        pass
 
     @staticmethod
     def gather_actions(blender_object, blender_actions, blender_tracks, action_on_type, export_settings):

--- a/addons/io_scene_gltf2_msfs/io/msfs_material_animation.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_material_animation.py
@@ -140,6 +140,25 @@ class MSFSMaterialAnimation:
             if material_index is None:
                 continue
 
-            target_property = channel["target"].path_from_id().split(".")[0]
-            if target_property == "msfs_color_albedo_mix": # TODO: add all possible targets
-                channel["target"] = f"materials/{material_index}/pbrMetallicRoughness/baseColorFactor"
+            blender_material = channel["target"]
+            target_property = blender_material.path_from_id().split(".")[0]
+            if blender_material.msfs_material_mode == "msfs_standard":
+                if target_property == "msfs_color_albedo_mix":
+                    channel["target"] = f"materials/{material_index}/pbrMetallicRoughness/baseColorFactor"
+                elif target_property == "msfs_color_emissive_mix":
+                    channel["target"] = f"materials/{material_index}/emissiveFactor"
+                elif target_property == "msfs_metallic_scale":
+                    channel["target"] = f"materials/{material_index}/pbrMetallicRoughness/metallicFactor"
+                elif target_property == "msfs_roughness_scale":
+                    channel["target"] = f"materials/{material_index}/pbrMetallicRoughness/roughnessFactor"
+            elif blender_material.msfs_material_mode == "msfs_env_occluder":
+                if target_property == "msfs_uv_offset_u":
+                    channel["target"] = f"materials/{material_index}/extensions/ASOBO_material_UV_options/UVOffsetU"
+                elif target_property == "msfs_uv_offset_v":
+                    channel["target"] = f"materials/{material_index}/extensions/ASOBO_material_UV_options/UVOffsetV"
+                elif target_property == "msfs_uv_tiling_u":
+                    channel["target"] = f"materials/{material_index}/extensions/ASOBO_material_UV_options/UVTilingU"
+                elif target_property == "msfs_uv_tiling_v":
+                    channel["target"] = f"materials/{material_index}/extensions/ASOBO_material_UV_options/UVTilingV"
+                elif target_property == "msfs_uv_rotation":
+                    channel["target"] = f"materials/{material_index}/extensions/ASOBO_material_UV_options/UVRotation"

--- a/addons/io_scene_gltf2_msfs/io/msfs_material_animation.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_material_animation.py
@@ -1,0 +1,33 @@
+# glTF-Blender-IO-MSFS
+# Copyright (C) 2020-2021 The glTF-Blender-IO-MSFS authors
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import math
+
+from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
+
+class MSFSMaterialAnimation:
+    bl_options = {"UNDO"}
+
+    def __new__(cls, *args, **kwargs):
+        raise RuntimeError("%s should not be instantiated" % cls)
+
+    @staticmethod
+    def create():
+        pass
+
+    @staticmethod
+    def export():
+        pass

--- a/addons/io_scene_gltf2_msfs/io/msfs_material_animation.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_material_animation.py
@@ -14,8 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import math
+import bpy
 
+from io_scene_gltf2.io.com import gltf2_io
+from io_scene_gltf2.blender.exp import gltf2_blender_gather_animation_samplers
+from io_scene_gltf2.blender.exp import gltf2_blender_gather_animation_channel_target
 from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
 
 class MSFSMaterialAnimation:
@@ -29,5 +32,95 @@ class MSFSMaterialAnimation:
         pass
 
     @staticmethod
-    def export():
-        pass
+    def gather_actions(blender_object, blender_actions, blender_tracks, action_on_type, export_settings):
+        # First step is to get a list of all material animation actions and NLA tracks (if used)
+        if blender_object.type == "MESH" \
+            and blender_object.data is not None \
+            and len(blender_object.material_slots) > 0:
+
+            for material_slot in blender_object.material_slots:
+                material = material_slot.material
+
+                if material is not None:
+                    if material.animation_data is not None: # Something to look out for - there may be circumstances where the animation data is actually in material.node_tree.animation_data
+                        if material.animation_data.action is not None:
+                            blender_actions.append(material.animation_data.action)
+                            blender_tracks[material.animation_data.action.name] = None
+                            action_on_type[material.animation_data.action.name] = "MATERIAL"
+
+                        # Collect associated strips from NLA tracks.
+                        if export_settings['gltf_nla_strips'] is True:
+                            for track in material.animation_data.nla_tracks:
+                                # Multi-strip tracks do not export correctly yet (they need to be baked),
+                                # so skip them for now and only write single-strip tracks.
+                                non_muted_strips = [strip for strip in track.strips if strip.action is not None and strip.mute is False]
+                                if track.strips is None or len(non_muted_strips) != 1:
+                                    continue
+                                for strip in non_muted_strips:
+                                    blender_actions.append(strip.action)
+                                    blender_tracks[strip.action.name] = track.name # Always set after possible active action -> None will be overwrite
+                                    action_on_type[material.animation_data.action.name] = "MATERIAL"
+
+    @staticmethod
+    def get_material_from_action(blender_object, blender_action):
+        blender_material = None
+        for material_slot in blender_object.material_slots:
+            material = material_slot.material
+            if material.animation_data is not None:
+                if blender_action == material.animation_data.action:
+                    blender_material = material
+                    break
+
+        return blender_material
+
+    @staticmethod
+    def replace_channel_target(gltf2_animation_channel, channels, blender_object, action_name):
+        blender_material = MSFSMaterialAnimation.get_material_from_action(blender_object, bpy.data.actions[action_name])
+        if blender_material is None:
+            return
+
+        for channel in channels:
+            try:
+                gltf2_animation_channel.target = blender_material.path_resolve(channel.data_path)
+            except ValueError:
+                continue
+            else:
+                return
+
+    @staticmethod
+    def finalize_animation(gltf2_animation, gltf2_plan):
+        material_animation_channels = []
+        for i, channel in enumerate(gltf2_animation.channels):
+            if not hasattr(channel.target, "id_data"):
+                continue
+
+            if type(channel.target.id_data) != bpy.types.Material:
+                continue
+            
+            material_index = None
+            for j, material in enumerate(gltf2_plan.materials):
+                if material.name == channel.target.id_data.name:
+                    material_index = j
+                    break
+            
+            if material_index is None:
+                continue
+
+            target_property = channel.target.path_from_id().split(".")[0]
+            if target_property == "msfs_color_albedo_mix": # TODO: add all possible targets
+                channel.target = f"materials/{j}/pbrMetallicRoughness/baseColorFactor"
+
+            material_animation_channels.append({
+                "sampler": channel.sampler,
+                "target": channel.target 
+            })
+            gltf2_animation.channels.pop(i)
+
+        if material_animation_channels:
+            gltf2_animation.extensions["ASOBO_property_animation"] = Extension(
+                name="ASOBO_property_animation",
+                extension={
+                    "channels": material_animation_channels
+                },
+                required=False
+            )


### PR DESCRIPTION
This PR adds the ability to animate and export our custom material properties.

Summary of changes:
- Refactor of how material properties are defined
    - Properties can be defined with 3 "sub-properties": `value`, `animated`, and `animated_on_type`
    - To get the value of these properties from now on, we need to access `value` from the prop.
- Allows export of material animations
- Export all UV options
- Change in how the material panel renders props (use `self.draw_prop()` now)

Remaining items:
- [ ] Cleanup code
- [ ] Wiper animations
- [ ] Channels being empty

The functionality in this PR only works in Blender 3.1 or newer.