### PR TITLE
feat: add addon version to asset generator string

### DIFF
--- a/addons/io_scene_gltf2_msfs/__init__.py
+++ b/addons/io_scene_gltf2_msfs/__init__.py
@@ -32,6 +32,9 @@ bl_info = {
     "tracker_url": "https://github.com/AsoboStudio/glTF-Blender-IO-MSFS"
 }
 
+def get_version_string():
+    return str(bl_info['version'][0]) + '.' + str(bl_info['version'][1]) + '.' + str(bl_info['version'][2])
+
 class MSFS_ExporterProperties(bpy.types.PropertyGroup):
     enabled: bpy.props.BoolProperty(
         name='Microsoft Flight Simulator Extensions',

--- a/addons/io_scene_gltf2_msfs/io/msfs_export.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_export.py
@@ -37,7 +37,6 @@ class Export:
                 required=False
             )
 
-            # Append addon version to generator
             gltf2_asset.generator += " and Asobo Studio MSFS Blender I/O v" + get_version_string()
 
     def gather_gltf_hook(self, gltf2_plan, export_settings):

--- a/addons/io_scene_gltf2_msfs/io/msfs_export.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_export.py
@@ -16,6 +16,7 @@
 
 import os
 import bpy
+from .. import get_version_string
 
 from .msfs_light import MSFSLight
 from .msfs_gizmo import MSFSGizmo
@@ -35,6 +36,9 @@ class Export:
                 extension={"tangent_space_convention": "DirectX"},
                 required=False
             )
+
+            # Append addon version to generator
+            gltf2_asset.generator += " and Asobo Studio MSFS Blender I/O v" + get_version_string()
 
     def gather_gltf_hook(self, gltf2_plan, export_settings):
         if self.properties.enabled:


### PR DESCRIPTION
This adds the current addon version to the asset generator. This is useful to keep track of any issues with older generated files