### PR TITLE
fix: bump versions and remove warning from addon

### DIFF
--- a/addons/io_scene_gltf2_msfs/__init__.py
+++ b/addons/io_scene_gltf2_msfs/__init__.py
@@ -24,10 +24,9 @@ bl_info = {
     "name": "Microsoft Flight Simulator glTF Extension",
     "author": "Luca Pierabella, Wing42, pepperoni505, ronh991, tml1024, and others",
     "description": "This toolkit prepares your 3D assets to be used for Microsoft Flight Simulator",
-    "blender": (3, 0, 0),
-    "version": (0, 0, 1),
+    "blender": (3, 1, 0),
+    "version": (1, 0, 3),
     "location": "File > Import-Export",
-    "warning": "This version of the addon is work-in-progress. Don't use it in your active development cycle, as it adds variables and objects to the scene that may cause issues further down the line.",
     "category": "Import-Export",
     "tracker_url": "https://github.com/AsoboStudio/glTF-Blender-IO-MSFS"
 }


### PR DESCRIPTION
We haven't changed the addon version at all, so this PR updates to our current version