### PR TITLE
feat: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_beta.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_beta.yaml
@@ -1,0 +1,52 @@
+name: Bug Report
+description: Report a bug
+labels: [Bug]
+body:
+- type: markdown
+  attributes:
+    value: "# glTF-Blender-IO-MSFS Bug Report Form"
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: A concise description of what you're experiencing.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1. In this environment...
+      2. With this config...
+      3. Run '...'
+      4. See error...
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Environment
+    description: |
+      examples:
+        - **OS**: Windows 11
+        - **Blender**: 3.0.1
+        - **glTF-Blender-IO-MSFS**: 1.0.0
+    value: |
+        - OS:
+        - Blender:
+        - glTF-Blender-IO-MSFS:
+    render: markdown
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Attatch a `.blend` file, provide pictures, references, or anything that will help us diagnose your issue.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/bug_report_beta.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_beta.yaml
@@ -16,7 +16,7 @@ body:
     label: Expected Behavior
     description: A concise description of what you expected to happen.
   validations:
-    required: false
+    required: true
 - type: textarea
   attributes:
     label: Steps To Reproduce
@@ -27,7 +27,7 @@ body:
       3. Run '...'
       4. See error...
   validations:
-    required: false
+    required: true
 - type: textarea
   attributes:
     label: Environment
@@ -42,7 +42,7 @@ body:
         - glTF-Blender-IO-MSFS:
     render: markdown
   validations:
-    required: false
+    required: true
 - type: textarea
   attributes:
     label: Anything else?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true


### PR DESCRIPTION
This PR adds an issue template, which will help users report issues that are more concise.
This uses GitHub's new issue form feature (https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms)

Here's a preview of what it will look like for a user:
![issue-template](https://user-images.githubusercontent.com/49950581/156646999-19a653a7-b345-454e-a63a-e7ce81c6292b.png)

