### PR TITLE
fix: calculate gizmo translation and rotation based off parent

### DIFF
--- a/addons/io_scene_gltf2_msfs/blender/gizmo.py
+++ b/addons/io_scene_gltf2_msfs/blender/gizmo.py
@@ -133,7 +133,7 @@ class MSFSCollisionGizmo(bpy.types.Gizmo):
         self.custom_shape_edges = edges
 
     def get_matrix(self):
-        # Re-calculate matrix without rotation
+        # Re-calculate matrix with proper scale
         if self.empty.msfs_gizmo_type == "sphere":
             scale = self.empty.scale[0] * self.empty.scale[1] * self.empty.scale[2]
             scale_matrix = Matrix.Scale(scale, 4, (1, 0, 0)) @ Matrix.Scale(scale, 4, (0, 1, 0)) @ Matrix.Scale(scale, 4, (0, 0, 1))
@@ -142,7 +142,10 @@ class MSFSCollisionGizmo(bpy.types.Gizmo):
             scale_matrix = Matrix.Scale(scale_xy, 4, (1, 0, 0)) @ Matrix.Scale(scale_xy, 4, (0, 1, 0)) @ Matrix.Scale(self.empty.scale[2], 4, (0, 0, 1))
         else:
             scale_matrix = Matrix.Scale(self.empty.scale[0], 4, (1, 0, 0)) @ Matrix.Scale(self.empty.scale[1], 4, (0, 1, 0)) @ Matrix.Scale(self.empty.scale[2], 4, (0, 0, 1))
-        matrix = Matrix.Translation(self.empty.matrix_world.translation) @ scale_matrix
+        if self.empty.rotation_mode == "QUATERNION":
+            matrix = Matrix.LocRotScale(self.empty.matrix_world.translation, self.empty.rotation_quaternion, scale_matrix.to_scale())
+        else:
+            matrix = Matrix.LocRotScale(self.empty.matrix_world.translation, self.empty.rotation_euler, scale_matrix.to_scale())
         return matrix
 
     def draw(self, context):

--- a/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
@@ -17,7 +17,7 @@
 import bpy
 import math
 
-import msfs_io_utilities
+from . import msfs_io_utilities
 
 from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
 
@@ -40,8 +40,12 @@ class MSFSGizmo:
                     bpy.ops.object.empty_add()
                     gizmo = bpy.context.object
 
-                    # Set gizmo location
-                    gizmo.location = gizmo_object.get("translation")
+                    if gizmo_object.get("translation"):
+                        parent_center = msfs_io_utilities.get_bounding_box_center(blender_object)
+                        gizmo.location = parent_center + msfs_io_utilities.gltf_location_to_blender(gizmo_object.get("translation"))
+                    if gizmo_object.get("rotation"):
+                        gizmo.rotation_mode = 'QUATERNION'
+                        gizmo.rotation_quaternion = msfs_io_utilities.gltf_rotation_to_blender(gizmo_object.get("rotation"))
 
                     # Set gizmo type and rename gizmo
                     type = gizmo_object.get("type")

--- a/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
@@ -60,6 +60,10 @@ class MSFSGizmo:
                         gizmo.scale[0] = params.get("radius")
                         gizmo.scale[1] = params.get("radius")
                         gizmo.scale[2] = params.get("radius")
+                    elif type == "box":
+                        gizmo.scale[0] = params.get("length")
+                        gizmo.scale[1] = params.get("width")
+                        gizmo.scale[2] = params.get("height")
                     elif type == "cylinder":
                         gizmo.scale[0] = params.get("radius")
                         gizmo.scale[1] = params.get("radius")

--- a/addons/io_scene_gltf2_msfs/io/msfs_io_utilities.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_io_utilities.py
@@ -90,7 +90,7 @@ def gltf_location_to_blender(loc):
 
 def gltf_rotation_to_blender(rot):
     """
-    Covnert glTF rotation to a blender Quaternion
+    Convert glTF rotation to a blender Quaternion
 
     :param rot: glTF rotation
     :return: Quaternion

--- a/addons/io_scene_gltf2_msfs/io/msfs_io_utilities.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_io_utilities.py
@@ -13,6 +13,7 @@
 
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import bpy
 from mathutils import Vector, Quaternion
 

--- a/addons/io_scene_gltf2_msfs/io/msfs_io_utilities.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_io_utilities.py
@@ -1,0 +1,70 @@
+# glTF-Blender-IO-MSFS
+# Copyright (C) 2022 The glTF-Blender-IO-MSFS authors
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import bpy
+from mathutils import Vector
+
+from io_scene_gltf2.blender.com.gltf2_blender_math import (
+    swizzle_yup_location,
+    swizzle_yup_rotation,
+)
+
+
+def get_flight_sim_location(node, parent_node):
+    """
+    For nodes such as a gizmo, we need to calculate location relative to the parent node
+
+    :param node: the blender node we want to get the location of
+    :param parent_node: the parent of the node
+    """
+
+    # Get parent node bounding box center
+    local_bbox_center = 0.125 * sum(
+        (Vector(b) for b in parent_node.bound_box), Vector()
+    )
+    global_bbox_center = (
+        parent_node.matrix_world * local_bbox_center
+    )  # TODO: do we need global? also order of matrix multiplication
+
+    transformed_matrix = node.matrix_local.inverted() @ global_bbox_center
+
+    loc = transformed_matrix.to_translation()
+
+    return swizzle_yup_location(loc)
+
+
+def get_flight_sim_rotation(node, parent_node):
+    """
+    For nodes such as a gizmo, we need to calculate rotation relative to the parent node
+
+    :param node: the blender node we want to get the rotation of
+    :param parent_node: the parent of the node
+    """
+    transformed_matrix = (
+        node.matrix_local @ parent_node.matrix_local.inverted()
+    )  # TODO: matrix order
+
+    # TODO: matrix decomposition?
+
+    return swizzle_yup_rotation(transformed_matrix.to_quaternion())
+
+
+def is_default_rotation(rotation):
+    return (
+        rotation[0] == 0.0
+        and rotation[1] == 0.0
+        and rotation[2] == 0.0
+        and (rotation[3] == 1.0 or rotation[3] == -1.0)
+    )


### PR DESCRIPTION
This (should) fix #57

Summary of changes:
- Calculate gizmo translation and rotation based off of parent
- Export gizmo rotation
- Import scale on box gizmos