### PR TITLE
refactor: import and export collision gizmos as nodes

### DIFF
--- a/addons/io_scene_gltf2_msfs/io/msfs_export.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_export.py
@@ -23,12 +23,9 @@ from .msfs_gizmo import MSFSGizmo
 from .msfs_material import MSFSMaterial
 
 class Export:
-
-    gizmoNodes = None
     
     def gather_asset_hook(self, gltf2_asset, export_settings):
         if self.properties.enabled == True:
-            self.gizmoNodes = []
             if gltf2_asset.extensions is None:
                 gltf2_asset.extensions = {}
             gltf2_asset.extensions["ASOBO_normal_map_convention"] = self.Extension(
@@ -46,8 +43,6 @@ class Export:
 
     def gather_node_hook(self, gltf2_object, blender_object, export_settings):
         if self.properties.enabled:
-            if blender_object.msfs_gizmo_type != "NONE":
-                self.gizmoNodes.append(gltf2_object)
 
             if gltf2_object.extensions is None:
                 gltf2_object.extensions = {}
@@ -55,29 +50,9 @@ class Export:
             if blender_object.type == 'LIGHT':
                 MSFSLight.export(gltf2_object, blender_object)
 
-    def gather_mesh_hook(self, gltf2_mesh, blender_mesh, blender_object, vertex_groups, modifiers, skip_filter, material_names, export_settings):
-        if self.properties.enabled:
-            # Set gizmo objects extension
-            MSFSGizmo.export(gltf2_mesh, blender_mesh)
-
     def gather_scene_hook(self, gltf2_scene, blender_scene, export_settings):
         if self.properties.enabled:
-            # Recursive function to filter children that are gizmos
-            def get_children(node):
-                children = []
-                for child in node.children:
-                    if child not in self.gizmoNodes:
-                        child.children = get_children(child)
-                        children.append(child)                        
-                return children
-
-            # Construct new node list with filtered children
-            new_nodes = []
-            for node in list(gltf2_scene.nodes.copy()):
-                node.children = get_children(node)
-                new_nodes.append(node)
-
-            gltf2_scene.nodes = new_nodes
+            MSFSGizmo.export(gltf2_scene.nodes, blender_scene, export_settings)
 
     def gather_material_hook(self, gltf2_material, blender_material, export_settings):
         if self.properties.enabled:

--- a/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
@@ -133,7 +133,7 @@ class MSFSGizmo:
             )  # The glTF exporter will ALWAYS set the node name as the blender name
 
             if (
-                blender_object.parent is None and blender_object.parent.type != "NONE"
+                blender_object.parent is None or blender_object.parent.type != "NONE"
             ):  # We only need the collision gizmos that are parented to a mesh
                 continue
 

--- a/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
@@ -148,6 +148,9 @@ class MSFSGizmo:
                     if child.rotation:
                         result["rotation"] = child.rotation
 
+                    if child.scale is None: # If the scale is default, it will be exported as None which will raise an error here
+                        child.scale = [1.0, 1.0, 1.0]
+
                     # Flip scale to match MSFS gizmo scale system
                     if export_settings["gltf_yup"]:
                         child.scale = [child.scale[2], child.scale[0], child.scale[1]]

--- a/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
@@ -17,110 +17,166 @@
 import bpy
 import math
 
+from io_scene_gltf2.io.com.gltf2_io import Node
 from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
 
 
-class MSFSGizmo():
+class MSFSGizmo:
     bl_options = {"UNDO"}
 
     extension_name = "ASOBO_gizmo_object"
 
     def __new__(cls, *args, **kwargs):
-            raise RuntimeError("%s should not be instantiated" % cls)
+        raise RuntimeError("%s should not be instantiated" % cls)
 
     @staticmethod
-    def create(gltf2_node, blender_object, import_settings):
-        gltf_mesh = import_settings.data.meshes[gltf2_node.mesh]
-        if gltf_mesh.extensions:
-            extension = gltf_mesh.extensions.get(MSFSGizmo.extension_name)
-            if extension:
-                for gizmo_object in extension.get("gizmo_objects"):
-                    bpy.ops.object.empty_add()
-                    gizmo = bpy.context.object
+    def create(gltf_scene, blender_scene, import_settings):
+        """
+        Create a "fake" node in the glTF scene to let the gizmo TRS get applied properly relative to the parent
+        """
+        nodes = gltf_scene.nodes
+        for node_idx in nodes:
+            node = import_settings.data.nodes[node_idx]
+            # Check extensions in mesh
+            if node.mesh is None:
+                continue
+            mesh = import_settings.data.meshes[node.mesh]
+            extension = mesh.extensions.get(MSFSGizmo.extension_name)
+            if extension is None:
+                continue
 
-                    # Set gizmo location
-                    gizmo.location = gizmo_object.get("translation")
+            for gizmo_object in extension.get("gizmo_objects"):
+                gizmo_type = gizmo_object.get("type")
+                params = gizmo_object.get("params", {})
 
-                    # Set gizmo type and rename gizmo
-                    type = gizmo_object.get("type")
-                    gizmo.msfs_gizmo_type = type
+                scale = [1.0, 1.0, 1.0]
+                if gizmo_type == "sphere":
+                    scale[0] = params.get("radius")
+                    scale[1] = params.get("radius")
+                    scale[2] = params.get("radius")
+                elif gizmo_type == "box":
+                    scale[0] = params.get("length")
+                    scale[1] = params.get("width")
+                    scale[2] = params.get("height")
+                elif gizmo_type == "cylinder":
+                    scale[0] = params.get("radius")
+                    scale[1] = params.get("radius")
+                    scale[2] = params.get("height")
 
-                    if type == "sphere":
-                        gizmo.name = "Sphere Collision"
-                    elif type == "box":
-                        gizmo.name = "Box Collision"
-                    elif type == "cylinder":
-                        gizmo.name = "Cylinder Collision"
+                placeholder_extension = {
+                    "gizmo_blender_data": {
+                        "road_collider": "Road"
+                        in gizmo_object.get("extensions", {})
+                        .get("ASOBO_tags", {})
+                        .get("tags", {}),
+                        "gizmo_type": gizmo_type,
+                    }
+                }
 
-                    # Get gizmo scale
-                    params = gizmo_object.get("params", {})
-                    if type == "sphere":
-                        gizmo.scale[0] = params.get("radius")
-                        gizmo.scale[1] = params.get("radius")
-                        gizmo.scale[2] = params.get("radius")
-                    elif type == "cylinder":
-                        gizmo.scale[0] = params.get("radius")
-                        gizmo.scale[1] = params.get("radius")
-                        gizmo.scale[2] = params.get("height")
+                # Create new placeholder node
+                placeholder_node = Node(
+                    camera=None,
+                    children=None,
+                    extensions=placeholder_extension,
+                    extras=None,
+                    matrix=None,
+                    mesh=None,
+                    name="Gizmo",
+                    rotation=gizmo_object.get("rotation"),
+                    scale=scale,
+                    skin=None,
+                    translation=gizmo_object.get("translation"),
+                    weights=None,
+                )
 
-                    # Set road collider
-                    if "Road" in gizmo_object.get("extensions", {}).get("ASOBO_tags", {}).get("tags"):
-                        gizmo.msfs_collision_is_road_collider = True
-
-                    gizmo.parent = blender_object
-
-                    # Set collection
-                    for collection in gizmo.users_collection:
-                        collection.objects.unlink(gizmo)
-                    blender_object.users_collection[0].objects.link(gizmo)
+                import_settings.data.nodes.append(placeholder_node)
+                if node.children is None:
+                    node.children = []
+                node.children.append(len(import_settings.data.nodes) - 1)
 
     @staticmethod
-    def export(gltf2_mesh, blender_mesh):
-        gizmo_objects = []
-        for object in bpy.context.scene.objects:
-            if object.type == "MESH" and bpy.data.meshes[object.data.name] == blender_mesh:
-                for child in object.children:
-                    if child.type == 'EMPTY' and child.msfs_gizmo_type != "NONE":
-                        gizmo_object = {}
-                        gizmo_object["translation"] = list(child.location)
-                        gizmo_object["type"] = child.msfs_gizmo_type
+    def set_blender_data(gltf2_node, blender_object, import_settings):
+        """
+        Set proper gizmo properties on the blender object
+        """
+        if gltf2_node.extensions is None:
+            return
 
-                        if child.msfs_gizmo_type == "sphere":
-                            gizmo_object["params"] = {
-                                "radius": abs(child.scale.x * child.scale.y * child.scale.z)
-                            }
-                        elif child.msfs_gizmo_type == "box":
-                            gizmo_object["params"] = {
-                                "length": abs(child.scale.x),
-                                "width": abs(child.scale.y),
-                                "height": abs(child.scale.z)
-                            }
-                        elif child.msfs_gizmo_type == "cylinder":
-                            gizmo_object["params"] = {
-                                "radius": abs(child.scale.x * child.scale.y),
-                                "height": abs(child.scale.z)
-                            }
+        extension = gltf2_node.extensions.get("gizmo_blender_data")
+        if extension is None:
+            return
 
-                        tags = ["Collision"]
-                        if child.msfs_collision_is_road_collider:
-                            tags.append("Road")
+        blender_object.msfs_collision_is_road_collider = extension.get("road_collider")
+        blender_object.msfs_gizmo_type = extension.get("gizmo_type")
 
-                        gizmo_object["extensions"] = {
-                            "ASOBO_tags": Extension(
-                                name = "ASOBO_tags",
-                                extension = {
-                                    "tags": tags
-                                },
-                                required = False
-                            )
-                        }
-                        gizmo_objects.append(gizmo_object)
+        # Set name
+        if blender_object.msfs_gizmo_type == "sphere":
+            blender_object.name = "Sphere Collision"
+        elif blender_object.msfs_gizmo_type == "box":
+            blender_object.name = "Box Collision"
+        elif blender_object.msfs_gizmo_type == "cylinder":
+            blender_object.name = "Cylinder Collision"
 
-        if gizmo_objects:
-            gltf2_mesh.extensions[MSFSGizmo.extension_name] = Extension(
-                name = MSFSGizmo.extension_name,
-                extension = {
-                    "gizmo_objects": gizmo_objects
-                },
-                required = False
+        # The Khronos importer auto-calculates the empty display size, so we need to reset it to 1
+        blender_object.empty_display_size = 1.0
+
+    @staticmethod
+    def export(nodes, blender_scene, export_settings):
+        """
+        Let the Khronos exporter gather the gizmo to calculate the proper TRS with the parent to make sure everything is correct,
+        then remove the gizmo from the collected nodes and set the proper mesh extensions
+        """
+        for node in nodes:
+            collisions = []  # TODO: make sure node is mesh?
+            blender_object = blender_scene.objects.get(
+                node.name
+            )  # The glTF exporter will ALWAYS set the node name as the blender name
+
+            if (
+                blender_object.parent is None and blender_object.parent.type != "NONE"
+            ):  # We only need the collision gizmos that are parented to a mesh
+                continue
+
+            if blender_object.msfs_gizmo_type != "NONE":
+                result = {}
+                result["type"] = blender_object.msfs_gizmo_type
+                result["translation"] = node.translation
+                if node.rotation:
+                    result["rotation"] = node.rotation
+
+                # Calculate scale per gizmo type
+                scale = {}
+                if blender_object.msfs_gizmo_type == "sphere":
+                    scale["radius"] = abs(node.scale[0] * node.scale[1] * node.scale[2])
+                elif blender_object.msfs_gizmo_type == "box":
+                    scale["length"] = abs(node.scale[0])
+                    scale["width"] = abs(node.scale[1])
+                    scale["height"] = abs(node.scale[2])
+                elif blender_object.msfs_gizmo_type == "cylinder":
+                    scale["radius"] = abs(node.scale[0] * node.scale[1])
+                    scale["height"] = abs(node.scale[2])
+
+                result["params"] = scale
+
+                # Collision type
+                tags = ["Collision"]
+                if blender_object.msfs_collision_is_road_collider:
+                    tags.append("Road")
+
+                result["extensions"] = {
+                    "ASOBO_tags": Extension(
+                        name="ASOBO_tags", extension={"tags": tags}, required=False
+                    )
+                }
+
+                collisions.append(result)
+                node.children.remove(node)
+
+            MSFSGizmo.export(node.children, blender_scene, export_settings)
+
+        if collisions:
+            node.mesh.extensions[MSFSGizmo.extension_name] = Extension(
+                name=MSFSGizmo.extension_name,
+                extension={"gizmo_objects": collisions},
+                required=False,
             )

--- a/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
@@ -63,6 +63,9 @@ class MSFSGizmo:
                     scale[1] = params.get("radius")
                     scale[2] = params.get("height")
 
+                # Flip scale (MSFS and Blender are exported with YUP)
+                scale = [scale[0], scale[2], scale[1]]
+
                 placeholder_extension = {
                     "gizmo_blender_data": {
                         "road_collider": "Road"
@@ -144,6 +147,10 @@ class MSFSGizmo:
                     result["translation"] = child.translation
                     if child.rotation:
                         result["rotation"] = child.rotation
+
+                    # Flip scale if we're exporting with YUP
+                    if export_settings["gltf_yup"]:
+                        child.scale = [child.scale[0], child.scale[2], child.scale[1]]
 
                     # Calculate scale per gizmo type
                     scale = {}

--- a/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
@@ -55,16 +55,16 @@ class MSFSGizmo:
                     scale[1] = params.get("radius")
                     scale[2] = params.get("radius")
                 elif gizmo_type == "box":
-                    scale[0] = params.get("length")
-                    scale[1] = params.get("width")
-                    scale[2] = params.get("height")
+                    scale[0] = params.get("length") / 2
+                    scale[1] = params.get("width") / 2
+                    scale[2] = params.get("height") / 2
                 elif gizmo_type == "cylinder":
                     scale[0] = params.get("radius")
                     scale[1] = params.get("radius")
                     scale[2] = params.get("height")
 
-                # Flip scale (MSFS and Blender are exported with YUP)
-                scale = [scale[0], scale[2], scale[1]]
+                # Flip scale to convert from MSFS gizmo scale system
+                scale = [scale[1], scale[2], scale[0]]
 
                 placeholder_extension = {
                     "gizmo_blender_data": {
@@ -148,18 +148,20 @@ class MSFSGizmo:
                     if child.rotation:
                         result["rotation"] = child.rotation
 
-                    # Flip scale if we're exporting with YUP
+                    # Flip scale to match MSFS gizmo scale system
                     if export_settings["gltf_yup"]:
-                        child.scale = [child.scale[0], child.scale[2], child.scale[1]]
+                        child.scale = [child.scale[2], child.scale[0], child.scale[1]]
+                    else:
+                        child.scale = [child.scale[1], child.scale[0], child.scale[2]]
 
                     # Calculate scale per gizmo type
                     scale = {}
                     if blender_object.msfs_gizmo_type == "sphere":
                         scale["radius"] = abs(child.scale[0] * child.scale[1] * child.scale[2])
                     elif blender_object.msfs_gizmo_type == "box":
-                        scale["length"] = abs(child.scale[0])
-                        scale["width"] = abs(child.scale[1])
-                        scale["height"] = abs(child.scale[2])
+                        scale["length"] = abs(child.scale[0]) * 2
+                        scale["width"] = abs(child.scale[1]) * 2
+                        scale["height"] = abs(child.scale[2]) * 2
                     elif blender_object.msfs_gizmo_type == "cylinder":
                         scale["radius"] = abs(child.scale[0] * child.scale[1])
                         scale["height"] = abs(child.scale[2])

--- a/addons/io_scene_gltf2_msfs/io/msfs_import.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_import.py
@@ -29,8 +29,12 @@ class Import:
         MSFSLight.create(gltf2_node, blender_node, blender_light, import_settings)
 
     # Create gizmos
+    def gather_import_scene_before_hook(self, gltf_scene, blender_scene, import_settings):
+        MSFSGizmo.create(gltf_scene, blender_scene, import_settings)
+
+    # Set proper gizmo blender object properties
     def gather_import_node_after_hook(self, vnode, gltf2_node, blender_object, import_settings):
-        MSFSGizmo.create(gltf2_node, blender_object, import_settings)
+        MSFSGizmo.set_blender_data(gltf2_node, blender_object, import_settings)
 
     # Create materials
     def gather_import_material_after_hook(self, gltf2_material, vertex_color, blender_material, import_settings):


### PR DESCRIPTION
This changes the import and export process of collision gizmos to let the Khronos importer and exporter handle the TRS calculations. This will hopefully fix all TRS issues with the gizmos. 

Rotation property was also added to the gizmo, as it was missing before.


Fixes #57 