### PR TITLE
fix: dont create new gltf settings node tree if already exists

### DIFF
--- a/addons/io_scene_gltf2_msfs/blender/msfs_material_function.py
+++ b/addons/io_scene_gltf2_msfs/blender/msfs_material_function.py
@@ -205,12 +205,16 @@ class MSFS_Material:
         self.nodebsdf = self.addNode(
             "ShaderNodeBsdfPrincipled", {"location": (500.0, 0.0), "hide": False}
         )
-        gltfSettingsNodeTree = bpy.data.node_groups.new(
-            "glTF Settings", "ShaderNodeTree"
-        )
-        gltfSettingsNodeTree.nodes.new("NodeGroupInput")
-        gltfSettingsNodeTree.inputs.new("NodeSocketFloat", "Occlusion")
-        gltfSettingsNodeTree.inputs[0].default_value = 1.000
+        if bpy.data.node_groups.get(MSFS_ShaderNodes.glTFSettings.value):
+            gltfSettingsNodeTree = bpy.data.node_groups[MSFS_ShaderNodes.glTFSettings.value]
+        else:
+            gltfSettingsNodeTree = bpy.data.node_groups.new(
+                "glTF Settings", "ShaderNodeTree"
+            )
+            gltfSettingsNodeTree.nodes.new("NodeGroupInput")
+            gltfSettingsNodeTree.inputs.new("NodeSocketFloat", "Occlusion")
+            gltfSettingsNodeTree.inputs[0].default_value = 1.000
+
         self.nodeglTFSettings = self.addNode(
             "ShaderNodeGroup",
             {


### PR DESCRIPTION
Partially fixes #76

Previously, every time a new material was created we would make a new glTF Settings node tree, even though one already existed. This would cause it to be renamed with an incrementing value at the end, which wouldn't allow it to be properly exported. In this PR, we check if the node tree already exists, and use it