### PR TITLE
fix: some materials dont import properly

### DIFF
--- a/addons/io_scene_gltf2_msfs/blender/msfs_material_function.py
+++ b/addons/io_scene_gltf2_msfs/blender/msfs_material_function.py
@@ -719,15 +719,17 @@ class MSFS_Material:
 
     def setCompTex(self, tex):
         self.nodeCompTex = self.getNode(MSFS_ShaderNodes.compTex.value)
-        self.nodeCompTex.image = tex
-        self.nodeCompTex.image.colorspace_settings.name = "Non-Color"
-        self.updateCompLinks()
+        if tex is not None:
+            self.nodeCompTex.image = tex
+            self.nodeCompTex.image.colorspace_settings.name = "Non-Color"
+            self.updateCompLinks()
 
     def setDetailCompTex(self, tex):
         self.nodeDetailCompTex = self.getNode(MSFS_ShaderNodes.detailCompTex.value)
-        self.nodeDetailCompTex.image = tex
-        self.nodeDetailCompTex.image.colorspace_settings.name = "Non-Color"
-        self.updateCompLinks()
+        if tex is not None:
+            self.nodeDetailCompTex.image = tex
+            self.nodeDetailCompTex.image.colorspace_settings.name = "Non-Color"
+            self.updateCompLinks()
 
     def setRoughnessScale(self, scale):
         self.nodeRoughnessScale = self.getNode(MSFS_ShaderNodes.roughnessScale.value)
@@ -748,15 +750,17 @@ class MSFS_Material:
 
     def setDetailNormalTex(self, tex):
         self.nodeDetailNormalTex = self.getNode(MSFS_ShaderNodes.detailNormalTex.value)
-        self.nodeDetailNormalTex.image = tex
-        self.nodeDetailNormalTex.image.colorspace_settings.name = "Non-Color"
-        self.updateNormalLinks()
+        if tex is not None:
+            self.nodeDetailNormalTex.image = tex
+            self.nodeDetailNormalTex.image.colorspace_settings.name = "Non-Color"
+            self.updateNormalLinks()
 
     def setNormalTex(self, tex):
         self.nodeNormalTex = self.getNode(MSFS_ShaderNodes.normalTex.value)
-        self.nodeNormalTex.image = tex
-        self.nodeNormalTex.image.colorspace_settings.name = "Non-Color"
-        self.updateNormalLinks()
+        if tex is not None:
+            self.nodeNormalTex.image = tex
+            self.nodeNormalTex.image.colorspace_settings.name = "Non-Color"
+            self.updateNormalLinks()
 
     def updateNormalLinks(self):
         self.nodeNormalTex = self.getNode(MSFS_ShaderNodes.normalTex.value)

--- a/addons/io_scene_gltf2_msfs/com/msfs_material_props.py
+++ b/addons/io_scene_gltf2_msfs/com/msfs_material_props.py
@@ -346,7 +346,7 @@ class AsoboMaterialGeometryDecal:
         extension = extensions.get(
             AsoboMaterialGeometryDecal.SerializedName, {}
         )
-        if extension.get("enabled"):
+        if extension:
             blender_material.msfs_material_type = "msfs_geo_decal"
         if extension.get("baseColorBlendFactor"):
             blender_material.msfs_base_color_blend_factor = extension.get(
@@ -557,7 +557,7 @@ class AsoboDisableMotionBlur:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(AsoboDisableMotionBlur.SerializedName, {})
-        if extension.get("enabled"):
+        if extension:
             blender_material.msfs_disable_motion_blur = True
 
     @staticmethod
@@ -661,7 +661,7 @@ class AsoboAlphaModeDither:
         extension = extensions.get(
             AsoboAlphaModeDither.SerializedName, {}
         )
-        if extension.get("enabled"):
+        if extension:
             blender_material.msfs_alpha_mode = "DITHER"
 
     @staticmethod
@@ -691,7 +691,7 @@ class AsoboMaterialInvisible:
         extension = extensions.get(
             AsoboMaterialInvisible.SerializedName, {}
         )
-        if extension.get("enabled"):
+        if extension:
             blender_material.msfs_material_type = "msfs_invisible"
 
     @staticmethod
@@ -723,7 +723,7 @@ class AsoboMaterialEnvironmentOccluder:
         extension = extensions.get(
             AsoboMaterialEnvironmentOccluder.SerializedName, {}
         )
-        if extension.get("enabled"):
+        if extension:
             blender_material.msfs_material_type = "msfs_environment_occluder"
 
     @staticmethod
@@ -1143,7 +1143,7 @@ class AsoboMaterialFakeTerrain:
         extension = extensions.get(
             AsoboMaterialFakeTerrain.SerializedName, {}
         )
-        if extension.get("enabled"):
+        if extension:
             blender_material.msfs_material_type = "msfs_fake_terrain"
 
     @staticmethod

--- a/addons/io_scene_gltf2_msfs/com/msfs_material_props.py
+++ b/addons/io_scene_gltf2_msfs/com/msfs_material_props.py
@@ -1331,6 +1331,7 @@ class AsoboAnisotropic:
 class AsoboWindshield:
 
     SerializedName = "ASOBO_material_windshield_v2"
+    AlternateSerializedName = "ASOBO_material_windshield"
 
     class Defaults:
         rainDropScale = 1.0
@@ -1385,6 +1386,9 @@ class AsoboWindshield:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(AsoboWindshield.SerializedName, {})
+        if not extension:
+            extension = extensions.get(AsoboWindshield.AlternateSerializedName, {})
+
         if extension:
             blender_material.msfs_material_type = "msfs_windshield"
             if extension.get("rainDropScale"):
@@ -1572,6 +1576,7 @@ class AsoboParallaxWindow:
 class AsoboGlass:
 
     SerializedName = "ASOBO_material_glass"
+    AlternateSerializedName = "ASOBO_material_kitty_glass"
 
     class Defaults:
         glassReflectionMaskFactor = 0.0
@@ -1600,6 +1605,9 @@ class AsoboGlass:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(AsoboGlass.SerializedName, {})
+        if not extension:
+            extension = extensions.get(AsoboGlass.AlternateSerializedName, {})
+
         if extension:
             blender_material.msfs_material_type = "msfs_glass"
             if extension.get("glassReflectionMaskFactor"):

--- a/addons/io_scene_gltf2_msfs/com/msfs_material_props.py
+++ b/addons/io_scene_gltf2_msfs/com/msfs_material_props.py
@@ -344,10 +344,13 @@ class AsoboMaterialGeometryDecal:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(
-            AsoboMaterialGeometryDecal.SerializedName, {}
+            AsoboMaterialGeometryDecal.SerializedName
         )
-        if extension:
-            blender_material.msfs_material_type = "msfs_geo_decal"
+        if extension is None:
+            return
+
+        blender_material.msfs_material_type = "msfs_geo_decal"
+
         if extension.get("baseColorBlendFactor"):
             blender_material.msfs_base_color_blend_factor = extension.get(
                 "baseColorBlendFactor"
@@ -432,8 +435,11 @@ class AsoboMaterialGhostEffect:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(
-            AsoboMaterialGhostEffect.SerializedName, {}
+            AsoboMaterialGhostEffect.SerializedName
         )
+        if extension is None:
+            return
+
         if extension.get("bias"):
             blender_material.msfs_ghost_bias = extension.get("bias")
         if extension.get("scale"):
@@ -482,8 +488,11 @@ class AsoboMaterialDrawOrder:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(
-            AsoboMaterialDrawOrder.SerializedName, {}
+            AsoboMaterialDrawOrder.SerializedName
         )
+        if extension is None:
+            return
+
         if extension.get("drawOrderOffset"):
             blender_material.msfs_draw_order_offset = extension.get("drawOrderOffset")
 
@@ -524,8 +533,10 @@ class AsoboDayNightCycle:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(AsoboDayNightCycle.SerializedName)
-        if extension is not None:
-            blender_material.msfs_day_night_cycle = True
+        if extension is None:
+            return
+
+        blender_material.msfs_day_night_cycle = True
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):
@@ -556,9 +567,11 @@ class AsoboDisableMotionBlur:
             return
 
         assert isinstance(extensions, dict)
-        extension = extensions.get(AsoboDisableMotionBlur.SerializedName, {})
-        if extension:
-            blender_material.msfs_disable_motion_blur = True
+        extension = extensions.get(AsoboDisableMotionBlur.SerializedName)
+        if extension is None:
+            return
+
+        blender_material.msfs_disable_motion_blur = True
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):
@@ -621,9 +634,12 @@ class AsoboPearlescent:
             return
 
         assert isinstance(extensions, dict)
-        extension = extensions.get(AsoboPearlescent.SerializedName, {})
-        if extension:
-            blender_material.msfs_use_pearl = True
+        extension = extensions.get(AsoboPearlescent.SerializedName)
+        if extension is None:
+            return
+
+        blender_material.msfs_use_pearl = True
+
         if extension.get("pearlShift"):
             blender_material.msfs_pearl_shift = extension.get("pearlShift")
         if extension.get("pearlRange"):
@@ -659,10 +675,12 @@ class AsoboAlphaModeDither:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(
-            AsoboAlphaModeDither.SerializedName, {}
+            AsoboAlphaModeDither.SerializedName
         )
-        if extension:
-            blender_material.msfs_alpha_mode = "DITHER"
+        if extension is None:
+            return
+
+        blender_material.msfs_alpha_mode = "DITHER"
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):
@@ -689,10 +707,12 @@ class AsoboMaterialInvisible:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(
-            AsoboMaterialInvisible.SerializedName, {}
+            AsoboMaterialInvisible.SerializedName
         )
-        if extension:
-            blender_material.msfs_material_type = "msfs_invisible"
+        if extension is None:
+            return
+
+        blender_material.msfs_material_type = "msfs_invisible"
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):
@@ -721,10 +741,12 @@ class AsoboMaterialEnvironmentOccluder:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(
-            AsoboMaterialEnvironmentOccluder.SerializedName, {}
+            AsoboMaterialEnvironmentOccluder.SerializedName
         )
-        if extension:
-            blender_material.msfs_material_type = "msfs_environment_occluder"
+        if extension is None:
+            return
+
+        blender_material.msfs_material_type = "msfs_environment_occluder"
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):
@@ -820,8 +842,11 @@ class AsoboMaterialUVOptions:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(
-            AsoboMaterialUVOptions.SerializedName, {}
+            AsoboMaterialUVOptions.SerializedName
         )
+        if extension is None:
+            return
+
         if extension.get("AOUseUV2"):
             blender_material.msfs_ao_use_uv2 = extension.get("AOUseUV2")
         if extension.get("clampUVX"):
@@ -904,8 +929,11 @@ class AsoboMaterialShadowOptions:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(
-            AsoboMaterialShadowOptions.SerializedName, {}
+            AsoboMaterialShadowOptions.SerializedName
         )
+        if extension is None:
+            return
+
         if extension.get("noCastShadow"):
             blender_material.msfs_no_cast_shadow = extension.get("noCastShadow")
 
@@ -945,8 +973,11 @@ class AsoboMaterialResponsiveAAOptions:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(
-            AsoboMaterialResponsiveAAOptions.SerializedName, {}
+            AsoboMaterialResponsiveAAOptions.SerializedName
         )
+        if extension is None:
+            return
+
         if extension.get("responsiveAA"):
             blender_material.msfs_responsive_aa = extension.get("responsiveAA")
 
@@ -1025,8 +1056,11 @@ class AsoboMaterialDetail:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(
-            AsoboMaterialDetail.SerializedName, {}
+            AsoboMaterialDetail.SerializedName
         )
+        if extension is None:
+            return
+
         if extension.get("UVScale"):
             blender_material.msfs_detail_uv_scale = extension.get("UVScale")
         if extension.get("UVOffset"):
@@ -1141,10 +1175,12 @@ class AsoboMaterialFakeTerrain:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(
-            AsoboMaterialFakeTerrain.SerializedName, {}
+            AsoboMaterialFakeTerrain.SerializedName
         )
-        if extension:
-            blender_material.msfs_material_type = "msfs_fake_terrain"
+        if extension is None:
+            return
+
+        blender_material.msfs_material_type = "msfs_fake_terrain"
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):
@@ -1192,16 +1228,19 @@ class AsoboMaterialFresnelFade:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(
-            AsoboMaterialFresnelFade.SerializedName, {}
+            AsoboMaterialFresnelFade.SerializedName
         )
-        if extension:
-            blender_material.msfs_material_type = "msfs_fresnel_fade"
-            if extension.get("fresnelFactor"):
-                blender_material.msfs_fresnel_factor = extension.get("fresnelFactor")
-            if extension.get("fresnelOpacityOffset"):
-                blender_material.msfs_fresnel_opacity_offset = extension.get(
-                    "fresnelOpacityOffset"
-                )
+        if extension is None:
+            return
+        
+        blender_material.msfs_material_type = "msfs_fresnel_fade"
+
+        if extension.get("fresnelFactor"):
+            blender_material.msfs_fresnel_factor = extension.get("fresnelFactor")
+        if extension.get("fresnelOpacityOffset"):
+            blender_material.msfs_fresnel_opacity_offset = extension.get(
+                "fresnelOpacityOffset"
+            )
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):
@@ -1249,15 +1288,18 @@ class AsoboSSS:
             return
 
         assert isinstance(extensions, dict)
-        extension = extensions.get(AsoboSSS.SerializedName, {})
-        if extension:
-            blender_material.msfs_material_type = "msfs_sss"
-            if extension.get("SSSColor"):
-                blender_material.msfs_sss_color = extension.get("SSSColor")
-            if extension.get("opacityTexture"):
-                blender_material.msfs_opacity_texture = MSFSMaterial.create_image(
-                    extension.get("opacityTexture", {}).get("index"), import_settings
-                )
+        extension = extensions.get(AsoboSSS.SerializedName)
+        if extension is None:
+            return
+
+        blender_material.msfs_material_type = "msfs_sss"
+
+        if extension.get("SSSColor"):
+            blender_material.msfs_sss_color = extension.get("SSSColor")
+        if extension.get("opacityTexture"):
+            blender_material.msfs_opacity_texture = MSFSMaterial.create_image(
+                extension.get("opacityTexture", {}).get("index"), import_settings
+            )
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):
@@ -1295,17 +1337,19 @@ class AsoboAnisotropic:
             return
 
         assert isinstance(extensions, dict)
-        extension = extensions.get(AsoboAnisotropic.SerializedName, {})
-        if extension:
-            # MUST BE CALLED AFTER SSS
-            if blender_material.msfs_material_type == "msfs_sss":
-                blender_material.msfs_material_type = "msfs_hair"  # SSS and hair share identical properties, except for this. If present, switch from SSS to hair
-            else:
-                blender_material.msfs_material_type = "msfs_anisotropic"
-            if extension.get("anisotropicTexture"):
-                blender_material.msfs_extra_slot1_texture = MSFSMaterial.create_image(
-                    extension.get("anisotropicTexture", {}).get("index"), import_settings
-                )
+        extension = extensions.get(AsoboAnisotropic.SerializedName)
+        if extension is None:
+            return
+
+        # MUST BE CALLED AFTER SSS
+        if blender_material.msfs_material_type == "msfs_sss":
+            blender_material.msfs_material_type = "msfs_hair"  # SSS and hair share identical properties, except for this. If present, switch from SSS to hair
+        else:
+            blender_material.msfs_material_type = "msfs_anisotropic"
+        if extension.get("anisotropicTexture"):
+            blender_material.msfs_extra_slot1_texture = MSFSMaterial.create_image(
+                extension.get("anisotropicTexture", {}).get("index"), import_settings
+            )
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):
@@ -1385,26 +1429,28 @@ class AsoboWindshield:
             return
 
         assert isinstance(extensions, dict)
-        extension = extensions.get(AsoboWindshield.SerializedName, {})
+        extension = extensions.get(AsoboWindshield.SerializedName)
         if not extension:
-            extension = extensions.get(AsoboWindshield.AlternateSerializedName, {})
+            extension = extensions.get(AsoboWindshield.AlternateSerializedName)
+        if extension is None:
+            return
 
-        if extension:
-            blender_material.msfs_material_type = "msfs_windshield"
-            if extension.get("rainDropScale"):
-                blender_material.msfs_rain_drop_scale = extension.get("rainDropScale")
-            if extension.get("wiper1State"):
-                blender_material.msfs_wiper_1_state = extension.get("wiper1State")
-            if extension.get("wiper2State"):
-                blender_material.msfs_wiper_2_state = extension.get("wiper2State")
-            if extension.get("wiper3State"):
-                blender_material.msfs_wiper_3_state = extension.get("wiper3State")
-            if extension.get("wiper4State"):
-                blender_material.msfs_wiper_4_state = extension.get("wiper4State")
-            if extension.get("wiperMaskTexture"):
-                blender_material.msfs_extra_slot1_texture = MSFSMaterial.create_image(
-                    extension.get("wiperMaskTexture", {}).get("index"), import_settings
-                )
+        blender_material.msfs_material_type = "msfs_windshield"
+
+        if extension.get("rainDropScale"):
+            blender_material.msfs_rain_drop_scale = extension.get("rainDropScale")
+        if extension.get("wiper1State"):
+            blender_material.msfs_wiper_1_state = extension.get("wiper1State")
+        if extension.get("wiper2State"):
+            blender_material.msfs_wiper_2_state = extension.get("wiper2State")
+        if extension.get("wiper3State"):
+            blender_material.msfs_wiper_3_state = extension.get("wiper3State")
+        if extension.get("wiper4State"):
+            blender_material.msfs_wiper_4_state = extension.get("wiper4State")
+        if extension.get("wiperMaskTexture"):
+            blender_material.msfs_extra_slot1_texture = MSFSMaterial.create_image(
+                extension.get("wiperMaskTexture", {}).get("index"), import_settings
+            )
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):
@@ -1443,13 +1489,16 @@ class AsoboClearCoat:
             return
 
         assert isinstance(extensions, dict)
-        extension = extensions.get(AsoboClearCoat.SerializedName, {})
-        if extension:
-            blender_material.msfs_material_type = "msfs_clearcoat"
-            if extension.get("dirtTexture"):
-                blender_material.msfs_dirt_texture = MSFSMaterial.create_image(
-                    extension.get("dirtTexture", {}).get("index"), import_settings
-                )
+        extension = extensions.get(AsoboClearCoat.SerializedName)
+        if extension is None:
+            return
+
+        blender_material.msfs_material_type = "msfs_clearcoat"
+
+        if extension.get("dirtTexture"):
+            blender_material.msfs_dirt_texture = MSFSMaterial.create_image(
+                extension.get("dirtTexture", {}).get("index"), import_settings
+            )
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):
@@ -1527,24 +1576,26 @@ class AsoboParallaxWindow:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(
-            AsoboParallaxWindow.SerializedName, {}
+            AsoboParallaxWindow.SerializedName
         )
-        if extension:
-            blender_material.msfs_material_type = "msfs_parallax"
-            if extension.get("parallaxScale"):
-                blender_material.msfs_parallax_scale = extension.get("parallaxScale")
-            if extension.get("roomSizeXScale"):
-                blender_material.msfs_parallax_room_size_x = extension.get("roomSizeXScale")
-            if extension.get("roomSizeYScale"):
-                blender_material.msfs_parallax_room_size_y = extension.get("roomSizeYScale")
-            if extension.get("roomNumberXY"):
-                blender_material.msfs_parallax_room_number_xy = extension.get("roomNumberXY")
-            if extension.get("corridor"):
-                blender_material.msfs_parallax_corridor = extension.get("corridor")
-            if extension.get("behindWindowMapTexture"):
-                blender_material.msfs_detail_color_texture = MSFSMaterial.create_image(
-                    extension.get("behindWindowMapTexture", {}).get("index"), import_settings
-                )
+        if extension is None:
+            return
+
+        blender_material.msfs_material_type = "msfs_parallax"
+        if extension.get("parallaxScale"):
+            blender_material.msfs_parallax_scale = extension.get("parallaxScale")
+        if extension.get("roomSizeXScale"):
+            blender_material.msfs_parallax_room_size_x = extension.get("roomSizeXScale")
+        if extension.get("roomSizeYScale"):
+            blender_material.msfs_parallax_room_size_y = extension.get("roomSizeYScale")
+        if extension.get("roomNumberXY"):
+            blender_material.msfs_parallax_room_number_xy = extension.get("roomNumberXY")
+        if extension.get("corridor"):
+            blender_material.msfs_parallax_corridor = extension.get("corridor")
+        if extension.get("behindWindowMapTexture"):
+            blender_material.msfs_detail_color_texture = MSFSMaterial.create_image(
+                extension.get("behindWindowMapTexture", {}).get("index"), import_settings
+            )
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):
@@ -1604,20 +1655,22 @@ class AsoboGlass:
             return
 
         assert isinstance(extensions, dict)
-        extension = extensions.get(AsoboGlass.SerializedName, {})
+        extension = extensions.get(AsoboGlass.SerializedName)
         if not extension:
-            extension = extensions.get(AsoboGlass.AlternateSerializedName, {})
+            extension = extensions.get(AsoboGlass.AlternateSerializedName)
+        if extension is None:
+            return
 
-        if extension:
-            blender_material.msfs_material_type = "msfs_glass"
-            if extension.get("glassReflectionMaskFactor"):
-                blender_material.msfs_glass_reflection_mask_factor = extension.get(
-                    "glassReflectionMaskFactor"
-                )
-            if extension.get("glassDeformationFactor"):
-                blender_material.msfs_glass_deformation_factor = extension.get(
-                    "glassDeformationFactor"
-                )
+        blender_material.msfs_material_type = "msfs_glass"
+
+        if extension.get("glassReflectionMaskFactor"):
+            blender_material.msfs_glass_reflection_mask_factor = extension.get(
+                "glassReflectionMaskFactor"
+            )
+        if extension.get("glassDeformationFactor"):
+            blender_material.msfs_glass_deformation_factor = extension.get(
+                "glassDeformationFactor"
+            )
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):
@@ -1662,11 +1715,13 @@ class AsoboTags:
 
         assert isinstance(extensions, dict)
         extension = extensions.get(AsoboTags.SerializedName, [])
-        if extension:
-            if AsoboTags.AsoboTag.Collision in extension.get("tags"):
-                blender_material.msfs_collision_material = True
-            if AsoboTags.AsoboTag.Road in extension.get("tags"):
-                blender_material.msfs_road_collision_material = True
+        if extension is None:
+            return
+
+        if AsoboTags.AsoboTag.Collision in extension.get("tags"):
+            blender_material.msfs_collision_material = True
+        if AsoboTags.AsoboTag.Road in extension.get("tags"):
+            blender_material.msfs_road_collision_material = True
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):
@@ -1704,15 +1759,17 @@ class AsoboMaterialCode:
 
         assert isinstance(extras, dict)
         extension = extras.get(AsoboMaterialCode.SerializedName)
-        if extension:
-            if extension == AsoboMaterialCode.MaterialCode.Windshield:
-                blender_material.msfs_material_type = "msfs_windshield"
-            elif extension == AsoboMaterialCode.MaterialCode.Porthole:
-                blender_material.msfs_material_type = "msfs_porthole"
-            elif extension == AsoboMaterialCode.MaterialCode.GeoDecalFrosted:
-                blender_material.msfs_material_type = "msfs_geo_decal_frosted"
-            elif extension == AsoboMaterialCode.MaterialCode.ClearCoat:
-                blender_material.msfs_material_type = "msfs_clearcoat"
+        if extension is None:
+            return
+
+        if extension == AsoboMaterialCode.MaterialCode.Windshield:
+            blender_material.msfs_material_type = "msfs_windshield"
+        elif extension == AsoboMaterialCode.MaterialCode.Porthole:
+            blender_material.msfs_material_type = "msfs_porthole"
+        elif extension == AsoboMaterialCode.MaterialCode.GeoDecalFrosted:
+            blender_material.msfs_material_type = "msfs_geo_decal_frosted"
+        elif extension == AsoboMaterialCode.MaterialCode.ClearCoat:
+            blender_material.msfs_material_type = "msfs_clearcoat"
 
     @staticmethod
     def to_extension(blender_material, gltf2_material, export_settings):

--- a/addons/io_scene_gltf2_msfs/com/msfs_material_props.py
+++ b/addons/io_scene_gltf2_msfs/com/msfs_material_props.py
@@ -1714,7 +1714,7 @@ class AsoboTags:
             return
 
         assert isinstance(extensions, dict)
-        extension = extensions.get(AsoboTags.SerializedName, [])
+        extension = extensions.get(AsoboTags.SerializedName)
         if extension is None:
             return
 

--- a/addons/io_scene_gltf2_msfs/com/msfs_material_props.py
+++ b/addons/io_scene_gltf2_msfs/com/msfs_material_props.py
@@ -233,18 +233,10 @@ class AsoboMaterialCommon:
             return
 
         assert isinstance(extensions, dict)
-        # If any Asobo extensions are present, set blender_material to standard. If the blender_material is another type, it will get changed later. This is the only way to see if it's a flight sim blender_material
-        for key in extensions.keys():
-            if key.upper().startswith("ASOBO_"):
-                blender_material.msfs_material_type = "msfs_standard"
-                break
-
-        if gltf2_material.alpha_mode == "MASK": # There are cases where the only non-standard material change is the alpha mode
+        # Every flight sim asset has ASOBO_normal_map_convention, so we check if it's being used to set material. We set blender_material to standard. If the blender_material is another type, it will get changed later.
+        if "ASOBO_normal_map_convention" in import_settings.data.extensions_used:
             blender_material.msfs_material_type = "msfs_standard"
 
-        if (
-            blender_material.msfs_material_type == "msfs_standard"
-        ):  # Only set properties if we are importing a flight sim blender_material
             if gltf2_material.pbr_metallic_roughness is not None:
                 if gltf2_material.pbr_metallic_roughness.base_color_factor is not None:
                     blender_material.msfs_base_color_factor = gltf2_material.pbr_metallic_roughness.base_color_factor

--- a/addons/io_scene_gltf2_msfs/com/msfs_material_props.py
+++ b/addons/io_scene_gltf2_msfs/com/msfs_material_props.py
@@ -239,6 +239,9 @@ class AsoboMaterialCommon:
                 blender_material.msfs_material_type = "msfs_standard"
                 break
 
+        if gltf2_material.alpha_mode == "MASK": # There are cases where the only non-standard material change is the alpha mode
+            blender_material.msfs_material_type = "msfs_standard"
+
         if (
             blender_material.msfs_material_type == "msfs_standard"
         ):  # Only set properties if we are importing a flight sim blender_material
@@ -343,6 +346,8 @@ class AsoboMaterialGeometryDecal:
         extension = extensions.get(
             AsoboMaterialGeometryDecal.SerializedName, {}
         )
+        if extension.get("enabled"):
+            blender_material.msfs_material_type = "msfs_geo_decal"
         if extension.get("baseColorBlendFactor"):
             blender_material.msfs_base_color_blend_factor = extension.get(
                 "baseColorBlendFactor"
@@ -365,6 +370,7 @@ class AsoboMaterialGeometryDecal:
             blender_material.msfs_material_type == "msfs_geo_decal"
             or blender_material.msfs_material_type == "msfs_geo_decal_frosted"
         ):
+            result["enabled"] = True
             result[
                 "baseColorBlendFactor"
             ] = blender_material.msfs_base_color_blend_factor
@@ -1689,15 +1695,15 @@ class AsoboMaterialCode:
             return
 
         assert isinstance(extras, dict)
-        extension = extras.get(AsoboMaterialCode.SerializedName, [])
+        extension = extras.get(AsoboMaterialCode.SerializedName)
         if extension:
-            if AsoboMaterialCode.MaterialCode.Windshield in extension:
+            if extension == AsoboMaterialCode.MaterialCode.Windshield:
                 blender_material.msfs_material_type = "msfs_windshield"
-            elif AsoboMaterialCode.MaterialCode.Porthole in extension:
+            elif extension == AsoboMaterialCode.MaterialCode.Porthole:
                 blender_material.msfs_material_type = "msfs_porthole"
-            elif AsoboMaterialCode.MaterialCode.GeoDecalFrosted in extension:
+            elif extension == AsoboMaterialCode.MaterialCode.GeoDecalFrosted:
                 blender_material.msfs_material_type = "msfs_geo_decal_frosted"
-            elif AsoboMaterialCode.MaterialCode.ClearCoat in extension:
+            elif extension == AsoboMaterialCode.MaterialCode.ClearCoat:
                 blender_material.msfs_material_type = "msfs_clearcoat"
 
     @staticmethod

--- a/addons/io_scene_gltf2_msfs/io/msfs_material.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_material.py
@@ -67,15 +67,9 @@ class MSFSMaterial:
         pyimg = import_settings.data.images[pytexture.source]
 
         # Find image created
-        blender_images = [image.name for image in bpy.data.images]
-        if pyimg.name in blender_images:
-            return bpy.data.images[pyimg.name]
-        elif pyimg.blender_image_name in blender_images:
-            return bpy.data.images[pyimg.blender_image_name]
-        elif os.path.basename(pyimg.uri) in blender_images:
-            return bpy.data.images[pyimg.uri]
-        elif "Image_%d" % index in blender_images:
-            return bpy.data.images["Image_%d" % index]
+        blender_image_name = pyimg.blender_image_name
+        if blender_image_name:
+            return bpy.data.images[blender_image_name]
 
     @staticmethod
     def export_image(

--- a/addons/io_scene_gltf2_msfs/io/msfs_material.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_material.py
@@ -67,13 +67,14 @@ class MSFSMaterial:
         pyimg = import_settings.data.images[pytexture.source]
 
         # Find image created
-        if pyimg.name in list(bpy.data.images):
+        blender_images = [image.name for image in bpy.data.images]
+        if pyimg.name in blender_images:
             return bpy.data.images[pyimg.name]
-        elif pyimg.blender_image_name in list(bpy.data.images):
+        elif pyimg.blender_image_name in blender_images:
             return bpy.data.images[pyimg.blender_image_name]
-        elif os.path.basename(pyimg.uri) in list(bpy.data.images):
+        elif os.path.basename(pyimg.uri) in blender_images:
             return bpy.data.images[pyimg.uri]
-        elif "Image_%d" % index in list(bpy.data.images):
+        elif "Image_%d" % index in blender_images:
             return bpy.data.images["Image_%d" % index]
 
     @staticmethod

--- a/addons/io_scene_gltf2_msfs/io/msfs_material.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_material.py
@@ -69,6 +69,8 @@ class MSFSMaterial:
         # Find image created
         if pyimg.name in list(bpy.data.images):
             return bpy.data.images[pyimg.name]
+        elif pyimg.blender_image_name in list(bpy.data.images):
+            return bpy.data.images[pyimg.blender_image_name]
         elif os.path.basename(pyimg.uri) in list(bpy.data.images):
             return bpy.data.images[pyimg.uri]
         elif "Image_%d" % index in list(bpy.data.images):

--- a/addons/io_scene_gltf2_msfs/io/msfs_material.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_material.py
@@ -30,6 +30,33 @@ from io_scene_gltf2.blender.exp.gltf2_blender_gather_texture_info import (
 class MSFSMaterial:
     bl_options = {"UNDO"}
 
+    extensions = [
+        MSFSMaterialExtensions.AsoboMaterialCommon,
+        MSFSMaterialExtensions.AsoboMaterialGeometryDecal,
+        MSFSMaterialExtensions.AsoboMaterialGhostEffect,
+        MSFSMaterialExtensions.AsoboMaterialDrawOrder,
+        MSFSMaterialExtensions.AsoboDayNightCycle,
+        MSFSMaterialExtensions.AsoboDisableMotionBlur,
+        MSFSMaterialExtensions.AsoboPearlescent,
+        MSFSMaterialExtensions.AsoboAlphaModeDither,
+        MSFSMaterialExtensions.AsoboMaterialInvisible,
+        MSFSMaterialExtensions.AsoboMaterialEnvironmentOccluder,
+        MSFSMaterialExtensions.AsoboMaterialUVOptions,
+        MSFSMaterialExtensions.AsoboMaterialShadowOptions,
+        MSFSMaterialExtensions.AsoboMaterialResponsiveAAOptions,
+        MSFSMaterialExtensions.AsoboMaterialDetail,
+        MSFSMaterialExtensions.AsoboMaterialFakeTerrain,
+        MSFSMaterialExtensions.AsoboMaterialFresnelFade,
+        MSFSMaterialExtensions.AsoboSSS,
+        MSFSMaterialExtensions.AsoboAnisotropic,
+        MSFSMaterialExtensions.AsoboWindshield,
+        MSFSMaterialExtensions.AsoboClearCoat,
+        MSFSMaterialExtensions.AsoboParallaxWindow,
+        MSFSMaterialExtensions.AsoboGlass,
+        MSFSMaterialExtensions.AsoboTags,
+        MSFSMaterialExtensions.AsoboMaterialCode,
+    ]
+
     def __new__(cls, *args, **kwargs):
         raise RuntimeError("%s should not be instantiated" % cls)
 
@@ -40,11 +67,11 @@ class MSFSMaterial:
         pyimg = import_settings.data.images[pytexture.source]
 
         # Find image created
-        if pyimg.name in bpy.data.images:
+        if pyimg.name in list(bpy.data.images):
             return bpy.data.images[pyimg.name]
-        elif os.path.basename(pyimg.uri) in bpy.data.images:
+        elif os.path.basename(pyimg.uri) in list(bpy.data.images):
             return bpy.data.images[pyimg.uri]
-        elif "Image_%d" % index in bpy.data.images:
+        elif "Image_%d" % index in list(bpy.data.images):
             return bpy.data.images["Image_%d" % index]
 
     @staticmethod
@@ -103,64 +130,10 @@ class MSFSMaterial:
 
     @staticmethod
     def create(gltf2_material, blender_material, import_settings):
-        extensions = [
-            MSFSMaterialExtensions.AsoboMaterialCommon,
-            MSFSMaterialExtensions.AsoboMaterialGeometryDecal,
-            MSFSMaterialExtensions.AsoboMaterialGhostEffect,
-            MSFSMaterialExtensions.AsoboMaterialDrawOrder,
-            MSFSMaterialExtensions.AsoboDayNightCycle,
-            MSFSMaterialExtensions.AsoboDisableMotionBlur,
-            MSFSMaterialExtensions.AsoboPearlescent,
-            MSFSMaterialExtensions.AsoboAlphaModeDither,
-            MSFSMaterialExtensions.AsoboMaterialInvisible,
-            MSFSMaterialExtensions.AsoboMaterialEnvironmentOccluder,
-            MSFSMaterialExtensions.AsoboMaterialUVOptions,
-            MSFSMaterialExtensions.AsoboMaterialShadowOptions,
-            MSFSMaterialExtensions.AsoboMaterialResponsiveAAOptions,
-            MSFSMaterialExtensions.AsoboMaterialDetail,
-            MSFSMaterialExtensions.AsoboMaterialFakeTerrain,
-            MSFSMaterialExtensions.AsoboMaterialFresnelFade,
-            MSFSMaterialExtensions.AsoboSSS,
-            MSFSMaterialExtensions.AsoboAnisotropic,
-            MSFSMaterialExtensions.AsoboWindshield,
-            MSFSMaterialExtensions.AsoboClearCoat,
-            MSFSMaterialExtensions.AsoboParallaxWindow,
-            MSFSMaterialExtensions.AsoboGlass,
-            MSFSMaterialExtensions.AsoboTags,
-            MSFSMaterialExtensions.AsoboMaterialCode,
-        ]
-
-        for extension in extensions:
+        for extension in MSFSMaterial.extensions:
             extension.from_dict(blender_material, gltf2_material, import_settings)
 
     @staticmethod
     def export(gltf2_material, blender_material, export_settings):
-        extensions = [
-            MSFSMaterialExtensions.AsoboMaterialCommon,
-            MSFSMaterialExtensions.AsoboMaterialGeometryDecal,
-            MSFSMaterialExtensions.AsoboMaterialGhostEffect,
-            MSFSMaterialExtensions.AsoboMaterialDrawOrder,
-            MSFSMaterialExtensions.AsoboDayNightCycle,
-            MSFSMaterialExtensions.AsoboDisableMotionBlur,
-            MSFSMaterialExtensions.AsoboPearlescent,
-            MSFSMaterialExtensions.AsoboAlphaModeDither,
-            MSFSMaterialExtensions.AsoboMaterialInvisible,
-            MSFSMaterialExtensions.AsoboMaterialEnvironmentOccluder,
-            MSFSMaterialExtensions.AsoboMaterialUVOptions,
-            MSFSMaterialExtensions.AsoboMaterialShadowOptions,
-            MSFSMaterialExtensions.AsoboMaterialResponsiveAAOptions,
-            MSFSMaterialExtensions.AsoboMaterialDetail,
-            MSFSMaterialExtensions.AsoboMaterialFakeTerrain,
-            MSFSMaterialExtensions.AsoboMaterialFresnelFade,
-            MSFSMaterialExtensions.AsoboSSS,
-            MSFSMaterialExtensions.AsoboAnisotropic,
-            MSFSMaterialExtensions.AsoboWindshield,
-            MSFSMaterialExtensions.AsoboClearCoat,
-            MSFSMaterialExtensions.AsoboParallaxWindow,
-            MSFSMaterialExtensions.AsoboGlass,
-            MSFSMaterialExtensions.AsoboTags,
-            MSFSMaterialExtensions.AsoboMaterialCode,
-        ]
-
-        for extension in extensions:
+        for extension in MSFSMaterial.extensions:
             extension.to_extension(blender_material, gltf2_material, export_settings)


### PR DESCRIPTION
This fixes a few issues:

- Colorspace being set even with no texture (causes error)
- If alpha mode is MASK, treat as MSFS material
- Material code treating string as list
- Create image throwing an error if the image is somehow None
- Don't check enabled property
- Add alternate serialized name (for extensions that have been renamed)
- Check blender image name on image during creation (some cases use this)
- Only import extensions if the SerializedName is present (sometimes we checked for properties without ensuring the extension was there)