### PR TITLE
fix: convert texture info to dictionary at export

### DIFF
--- a/addons/io_scene_gltf2_msfs/io/msfs_material.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_material.py
@@ -99,7 +99,7 @@ class MSFSMaterial:
         if type == "NORMAL":
             nodes.remove(normal_node)
 
-        return texture_info
+        return texture_info.to_dict()
 
     @staticmethod
     def create(gltf2_material, blender_material, import_settings):


### PR DESCRIPTION
This fixes a serialization error if certain textures are specified