### PR TITLE
fix: use first tuple for texture info if is tuple

### DIFF
--- a/addons/io_scene_gltf2_msfs/io/msfs_material.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_material.py
@@ -99,7 +99,11 @@ class MSFSMaterial:
         if type == "NORMAL":
             nodes.remove(normal_node)
 
-        return texture_info.to_dict()
+        # Some versions of the Khronos exporter have gather_texture_info return a tuple
+        if isinstance(texture_info, tuple):
+            texture_info = texture_info[0]
+
+        return texture_info
 
     @staticmethod
     def create(gltf2_material, blender_material, import_settings):


### PR DESCRIPTION
#104 was supposed to have fixed this issue - but after more investigation I discovered the issue stemmed from the fact that the Khronos exporter can return a tuple instead of just a texture info object