### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,14 @@ This repository represents an alpha version of the official FlightSim-Blender Im
 Asobo especially thanks:
 
 Vitus of [Wing42](https://wing42.com/), [tml1024](https://github.com/tml1024), [ronh991](https://github.com/ronh991), [pepperoni505](https://github.com/pepperoni505) of [FlyByWire](https://flybywiresim.com/)
+
+
+Installation
+===========
+
+1. Download the latest release
+2. Decompress the file
+3. Open the `addons` folder
+4. Copy-paste the `io_scene_gltf2_msfs` folder into your Blender installation's `scripts/addons/` folder.
+   1. Windows: this will usually be in `C:\Program Files\Blender Foundation\Blender 3.1\3.1\scripts\addons\`.
+   2. Mac OS X: this will be in your Library (Press the Option key when in Finder's `Go` menu to open your Library folder): `\Users\<username>\Library\Application Support\Blender\3.1\scripts\addons\`.


### PR DESCRIPTION
I thought installing it with the usual zip file method would work but that wasn't the case. I thought adding the installation documentation to the README file would be appropriate for non-Blender experts like me.