### PR TITLE
refactor: move ASOBO_macro_light to new serialization layout

### DIFF
--- a/addons/io_scene_gltf2_msfs/blender/li_properties.py
+++ b/addons/io_scene_gltf2_msfs/blender/li_properties.py
@@ -16,26 +16,5 @@
 
 import bpy
 
-from bpy.props import IntProperty, BoolProperty, StringProperty, FloatProperty, EnumProperty, FloatVectorProperty, PointerProperty
-
-class MSFS_attached_behavior(bpy.types.PropertyGroup):
-    name: bpy.props.StringProperty(name = "behavior", default = "")
-    source_file: bpy.props.StringProperty(name = "filepath", subtype='FILE_NAME', default = "")
-    source_filename: bpy.props.StringProperty(name = "filename", subtype='FILE_NAME', default = "")
-    kf_start: bpy.props.IntProperty(name = "kf_start", min=0,  default = 0)
-    kf_end: bpy.props.IntProperty(name = "kf_end", min=0,  default = 1)
-
-bpy.utils.register_class(MSFS_attached_behavior)
-
 class MSFS_LI_object_properties():
-    bpy.types.Object.msfs_behavior = bpy.props.CollectionProperty(type = MSFS_attached_behavior)
-    bpy.types.Object.msfs_active_behavior = bpy.props.IntProperty(name="Active behavior",min=0,default=0)
-
-    bpy.types.Object.msfs_light_has_symmetry = bpy.props.BoolProperty(name='Has symmetry',default=False)
-    bpy.types.Object.msfs_light_flash_frequency = bpy.props.FloatProperty(name='Flash frequency',min=0.0,default=0.0)
-    bpy.types.Object.msfs_light_flash_duration = bpy.props.FloatProperty(name='Flash duration',min=0.0,default=0.0)
-    bpy.types.Object.msfs_light_flash_phase = bpy.props.FloatProperty(name='Flash phase',default=0.0)
-    bpy.types.Object.msfs_light_rotation_speed = bpy.props.FloatProperty(name='Rotation speed',default=0.0)
-    bpy.types.Object.msfs_light_day_night_cycle = bpy.props.BoolProperty(name='Day/Night cycle',default=False,description="Set this value to 'true' if you want the light to be visible at night only.")
-
     bpy.types.Object.msfs_collision_is_road_collider = bpy.props.BoolProperty(name="Road Collider", default=False)

--- a/addons/io_scene_gltf2_msfs/blender/msfs_light_panel.py
+++ b/addons/io_scene_gltf2_msfs/blender/msfs_light_panel.py
@@ -1,0 +1,45 @@
+# glTF-Blender-IO-MSFS
+# Copyright (C) 2022 The glTF-Blender-IO-MSFS authors
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import bpy
+
+
+class MSFS_PT_Light(bpy.types.Panel):
+    bl_label = "MSFS Light Params"
+    bl_space_type = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context = "data"
+    bl_options = {"DEFAULT_CLOSED"}
+
+    @classmethod
+    def poll(cls, context):
+        return context.active_object.type == "LIGHT"
+
+    def draw(self, context):
+        layout = self.layout
+
+        obj = context.active_object
+
+        if obj:  # TODO: migrate?
+            layout.prop(obj, "msfs_light_color")
+            layout.prop(obj, "msfs_light_intensity")
+            layout.prop(obj, "msfs_light_cone_angle")
+            layout.prop(obj, "msfs_light_has_symmetry")
+            layout.prop(obj, "msfs_light_flash_frequency")
+            layout.prop(obj, "msfs_light_flash_duration")
+            layout.prop(obj, "msfs_light_flash_phase")
+            layout.prop(obj, "msfs_light_rotation_speed")
+            layout.prop(obj, "msfs_light_activation_mode")

--- a/addons/io_scene_gltf2_msfs/blender/ui_properties.py
+++ b/addons/io_scene_gltf2_msfs/blender/ui_properties.py
@@ -17,40 +17,6 @@
 import bpy
 import os
 
-# from .func_properties import *
-
-# class MSFS_UL_ObjectBehaviorListItem(bpy.types.UIList):
-#     bl_idname = "MSFS_UL_object_behaviorListItem"
-#     def draw_item(self, context, layout, data, item, icon, active_data, active_propname):
-#         split = layout.split(factor=0.65)
-#         split.label(text=item.name)
-#         split.label(text="(kf:%i-%i)"%(item.kf_start,item.kf_end))
-
-class MSFS_PT_BoneProperties(bpy.types.Panel):
-    bl_label = "MSFS Properties"
-    bl_idname = "BONE_PT_msfs_properties"
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_context = 'bone'
-    
-    def draw(self, context):
-        layout = self.layout
-        box=layout.box()
-        box.label(text = "Behavior list", icon = 'ANIM')
-        box.template_list('MSFS_UL_object_behaviorListItem', "", context.object, 'msfs_behavior', context.object, 'msfs_active_behavior')
-
-        if len(context.object.msfs_behavior) > context.object.msfs_active_behavior:
-            behavior = context.object.msfs_behavior[context.object.msfs_active_behavior]
-
-            subbox=box.box()
-            subbox.label(text=behavior.name,icon='OUTLINER_DATA_GP_LAYER')
-            if behavior.source_file != "":
-                subbox.label(text="XML: %s"%behavior.source_filename,icon='FILE')
-            split=subbox.split(factor=0.75)
-            split.label(text="Keyframes start: %i"%behavior.kf_start,icon='DECORATE_KEYFRAME')
-            split.label(text="end: %i"%behavior.kf_end)
-            subbox.operator('msfs.behavior_remove_selected_from_object',text="Remove selected behavior",icon='TRASH')
-
 class MSFS_PT_ObjectProperties(bpy.types.Panel):
     bl_label = "MSFS Properties"
     bl_idname = "OBJECT_PT_msfs_properties"
@@ -60,50 +26,16 @@ class MSFS_PT_ObjectProperties(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context):
-        return (context.object.type in ['LIGHT', 'EMPTY'])
+        return (context.object.type == 'EMPTY')
     
     def draw(self, context):
         layout = self.layout
 
         active_object = context.object
 
-        if active_object.type == 'LIGHT':
-            box = layout.box()
-            box.label(text = "MSFS Light Parameters", icon='LIGHT')
-            box.prop(active_object, 'msfs_light_has_symmetry')
-            box.prop(active_object, 'msfs_light_flash_frequency')
-            box.prop(active_object, 'msfs_light_flash_duration')
-            box.prop(active_object, 'msfs_light_flash_phase')
-            box.prop(active_object, 'msfs_light_rotation_speed')
-            box.prop(active_object, 'msfs_light_day_night_cycle')
-
-        elif active_object.type == 'EMPTY':
+        if active_object.type == 'EMPTY':
             box = layout.box()
             box.label(text="MSFS Collision Parameters", icon='SHADING_BBOX')
-            box.prop(active_object, "msfs_gizmo_type") # TODO: change to msfs_msfs_gizmo_type
+            box.prop(active_object, "msfs_gizmo_type")
             if active_object.msfs_gizmo_type != "NONE":
                 box.prop(active_object, "msfs_collision_is_road_collider")
-
-
-        #if bpy.context.active_object.type == 'ARMATURE':
-        #    box=layout.box()
-        #    box.label(text = "Behavior tags are stored in individual bones.", icon = 'ANIM')
-        #else:
-        #    box=layout.box()
-        #    box.label(text = "Behavior list", icon = 'ANIM')
-        #    box.template_list('OBJECTBEHAVIOR_UL_listItem', "", context.object, 'msfs_behavior', context.object, 'msfs_active_behavior')
-
-        #    if len(context.object.msfs_behavior) > context.object.msfs_active_behavior:
-        #        behavior = context.object.msfs_behavior[context.object.msfs_active_behavior]
-
-        #        subbox=box.box()
-        #        subbox.label(text=behavior.name,icon='OUTLINER_DATA_GP_LAYER')
-        #        if behavior.source_file != "":
-        #            subbox.label(text="XML: %s"%behavior.source_filename,icon='FILE')
-        #        split=subbox.split(factor=0.75)
-        #        split.label(text="Keyframes start: %i"%behavior.kf_start,icon='DECORATE_KEYFRAME')
-        #        split.label(text="end: %i"%behavior.kf_end)
-        #        subbox.operator('msfs.behavior_remove_selected_from_object',text="Remove selected behavior",icon='TRASH')
-
-
-

--- a/addons/io_scene_gltf2_msfs/com/msfs_light_props.py
+++ b/addons/io_scene_gltf2_msfs/com/msfs_light_props.py
@@ -1,0 +1,155 @@
+# glTF-Blender-IO-MSFS
+# Copyright (C) 2022 The glTF-Blender-IO-MSFS authors
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import bpy
+
+from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
+
+
+class AsoboMacroLight:
+
+    SerializedName = "ASOBO_macro_light"
+
+    class Defaults:
+        Color = [1.0, 1.0, 1.0]
+        Intensity = 1.0
+        ConeAngle = 90.0
+        HasSymmetry = False
+        FlashFrequency = 0.0
+        FlashDuration = 0.2
+        FlashPhase = 0.0
+        RotationSpeed = 0.0
+        Kelvin = 3600.0  # TODO: ????
+        ActivationMode = "ALWAYS_ON"
+
+    bpy.types.Object.msfs_light_color = bpy.props.FloatVectorProperty(
+        name="Color",
+        subtype="COLOR",
+        min=0.0,
+        max=1.0,
+        size=3,
+        default=Defaults.Color,  # TODO: update
+        options=set(),  # ANIMATABLE is a default item in options, so for properties that shouldn't be animatable, we have to overwrite this.
+    )
+    bpy.types.Object.msfs_light_intensity = bpy.props.FloatProperty(
+        name="Intensity",
+        min=0.0,
+        max=10000000.0,
+        default=Defaults.Intensity,
+        options=set(),
+    )
+    bpy.types.Object.msfs_light_cone_angle = bpy.props.FloatProperty(
+        name="Cone Angle",
+        min=0.0,
+        max=360.0,
+        default=Defaults.ConeAngle,
+        options=set(),
+    )
+    bpy.types.Object.msfs_light_has_symmetry = bpy.props.BoolProperty(
+        name="Has Symmetry",
+        default=Defaults.HasSymmetry,
+        options=set(),
+    )
+    bpy.types.Object.msfs_light_flash_frequency = bpy.props.FloatProperty(
+        name="Flash Frequency",
+        description="Flashes per minute",
+        min=0.0,
+        max=1000.0,
+        default=Defaults.FlashFrequency,
+        options=set(),
+    )
+    bpy.types.Object.msfs_light_flash_duration = bpy.props.FloatProperty(
+        name="Flash Duration",
+        description="Flash duration in seconds",
+        min=0.0,
+        max=1000.0,
+        default=Defaults.FlashDuration,
+        options=set(),
+    )
+    bpy.types.Object.msfs_light_flash_phase = bpy.props.FloatProperty(
+        name="Flash Phase",
+        description="Flash phase in seconds",
+        min=0.0,
+        max=1000.0,
+        default=Defaults.FlashPhase,
+        options=set(),
+    )
+    bpy.types.Object.msfs_light_rotation_speed = bpy.props.FloatProperty(
+        name="Rotation Speed",
+        description="Rotations per minute",
+        min=-1000.0,
+        max=1000.0,
+        default=Defaults.RotationSpeed,
+        options=set(),
+    )
+    bpy.types.Object.msfs_light_activation_mode = bpy.props.EnumProperty(
+        name="Activation Mode",
+        items=(
+            ("DAY_NIGHT_CYCLE", "Day/Night Cycle", ""),
+            ("ALWAYS_ON", "Always On", ""),
+        ),
+        default=Defaults.ActivationMode,
+    )
+
+    @staticmethod
+    def from_dict(blender_object, gltf2_node, import_settings):
+        extensions = gltf2_node.extensions
+        if extensions is None:
+            return
+
+        assert isinstance(extensions, dict)
+        extension = extensions.get(AsoboMacroLight.SerializedName)
+        if extension is None:
+            return
+
+        if extension.get("color"):
+            blender_object.msfs_light_color = extension.get("color")
+        if extension.get("intensity"):
+            blender_object.msfs_light_intensity = extension.get("intensity")
+        if extension.get("coneAngle"):
+            blender_object.msfs_light_cone_angle = extension.get("coneAngle")
+        if extension.get("hasSimmetry"):  # This is spelled incorrectly on purpose
+            blender_object.msfs_light_has_symmetry = extension.get("hasSimmetry")
+        if extension.get("flashFrequency"):
+            blender_object.msfs_light_flash_frequency = extension.get("flashFrequency")
+        if extension.get("dayNightCycle"):
+            blender_object.msfs_light_activation_mode = "DAY_NIGHT_CYCLE"
+        if extension.get("flashDuration"):
+            blender_object.msfs_light_flash_duration = extension.get("flashDuration")
+        if extension.get("flashPhase"):
+            blender_object.msfs_light_flash_phase = extension.get("flashPhase")
+        if extension.get("rotationSpeed"):
+            blender_object.msfs_light_rotation_speed = extension.get("rotationSpeed")
+
+    @staticmethod
+    def to_extension(blender_object, gltf2_node, export_settings):
+        result = {}
+        if blender_object.type == "LIGHT":
+            result["color"] = blender_object.msfs_light_color
+            result["intensity"] = blender_object.msfs_light_intensity
+            result["coneAngle"] = blender_object.msfs_light_cone_angle
+            result["hasSimmetry"] = blender_object.msfs_light_has_symmetry  # This is spelled incorrectly on purpose
+            result["flashFrequency"] = blender_object.msfs_light_flash_frequency
+            result["dayNightCycle"] = (blender_object.msfs_light_activation_mode == "DAY_NIGHT_CYCLE")  # TODO: is this right?
+            result["flashDuration"] = blender_object.msfs_light_flash_duration
+            result["flashPhase"] = blender_object.msfs_light_flash_phase
+            result["rotationSpeed"] = blender_object.msfs_light_rotation_speed
+
+            gltf2_node.extensions[AsoboMacroLight.SerializedName] = Extension(
+                name=AsoboMacroLight.SerializedName,
+                extension=result,
+                required=False,
+            )

--- a/addons/io_scene_gltf2_msfs/io/msfs_export.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_export.py
@@ -45,12 +45,7 @@ class Export:
 
     def gather_node_hook(self, gltf2_object, blender_object, export_settings):
         if self.properties.enabled:
-
-            if gltf2_object.extensions is None:
-                gltf2_object.extensions = {}
-
-            if blender_object.type == 'LIGHT':
-                MSFSLight.export(gltf2_object, blender_object)
+            MSFSLight.export(gltf2_object, blender_object, export_settings)
 
     def gather_scene_hook(self, gltf2_scene, blender_scene, export_settings):
         if self.properties.enabled:


### PR DESCRIPTION
This transitions the `ASOBO_macro_light` to use the new serialization layout as introduced in the material refactor.

To-do:
- [ ] Ensure matches 3DS Max
  - [ ] Kelvin?
- [ ] Fix rotation (#93)
- [ ] Proper importing and exporting with BOTH 3.1 and 3.2 (VTree changes)
- [ ] Migration
- [ ] Rendering
- [ ] Activation mode