### PR TITLE
added offset rotation to temporaly fix light issue

### DIFF
--- a/addons/io_scene_gltf2_msfs/io/msfs_light.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_light.py
@@ -17,7 +17,7 @@
 import math
 
 from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
-
+from mathutils import Matrix, Quaternion, Euler
 
 class MSFSLight:
     bl_options = {"UNDO"}
@@ -71,6 +71,13 @@ class MSFSLight:
         extension["rotation_speed"] = blender_object.msfs_light_rotation_speed
         extension["day_night_cycle"] = blender_object.msfs_light_day_night_cycle
 
+        # start quick dirty fix to solve rotationn problem 
+        # this can be removed after blender 3.2 goes out
+        currentRotationQuat = Quaternion((gltf2_object.rotation[3],gltf2_object.rotation[0],gltf2_object.rotation[1],gltf2_object.rotation[2])) if gltf2_object.rotation  else Quaternion()
+        quat_a = Quaternion((1.0, 0.0, 0.0), math.radians(90.0))
+        r =  currentRotationQuat @ quat_a
+        gltf2_object.rotation = [r.x,r.y,r.z,r.w]
+        #end quick fix
         gltf2_object.extensions[MSFSLight.extension_name] = Extension(
             name=MSFSLight.extension_name,
             extension=extension,


### PR DESCRIPTION
this should fix #93 

lights are not hooked properly, a strange child node with a rotation offset is added
I added a rotation of 90 degrees on X-axis by default.
This should solve the problem till the release of Blender 3.2 when the issue should be fixed