### PR TITLE
fix: various collision mesh issues

### DIFF
--- a/addons/io_scene_gltf2_msfs/blender/gizmo.py
+++ b/addons/io_scene_gltf2_msfs/blender/gizmo.py
@@ -136,13 +136,14 @@ class MSFSCollisionGizmo(bpy.types.Gizmo):
         # Re-calculate matrix without rotation
         if self.empty.msfs_gizmo_type == "sphere":
             scale = self.empty.scale[0] * self.empty.scale[1] * self.empty.scale[2]
-            scale_matrix = Matrix.Scale(scale, 4, (1, 0, 0)) @ Matrix.Scale(scale, 4, (0, 1, 0)) @ Matrix.Scale(scale, 4, (0, 0, 1))
+            scale_matrix = Matrix.Scale(scale, 3, (1, 0, 0)) @ Matrix.Scale(scale, 3, (0, 1, 0)) @ Matrix.Scale(scale, 3, (0, 0, 1))
         elif self.empty.msfs_gizmo_type == "cylinder":
             scale_xy = self.empty.scale[0] * self.empty.scale[1]
-            scale_matrix = Matrix.Scale(scale_xy, 4, (1, 0, 0)) @ Matrix.Scale(scale_xy, 4, (0, 1, 0)) @ Matrix.Scale(self.empty.scale[2], 4, (0, 0, 1))
+            scale_matrix = Matrix.Scale(scale_xy, 3, (1, 0, 0)) @ Matrix.Scale(scale_xy, 3, (0, 1, 0)) @ Matrix.Scale(self.empty.scale[2], 3, (0, 0, 1))
         else:
-            scale_matrix = Matrix.Scale(self.empty.scale[0], 4, (1, 0, 0)) @ Matrix.Scale(self.empty.scale[1], 4, (0, 1, 0)) @ Matrix.Scale(self.empty.scale[2], 4, (0, 0, 1))
-        matrix = Matrix.Translation(self.empty.matrix_world.translation) @ scale_matrix
+            scale_matrix = Matrix.Scale(self.empty.scale[0], 3, (1, 0, 0)) @ Matrix.Scale(self.empty.scale[1], 3, (0, 1, 0)) @ Matrix.Scale(self.empty.scale[2], 3, (0, 0, 1))
+
+        matrix = Matrix.LocRotScale(self.empty.matrix_world.to_translation(), self.empty.matrix_world.to_quaternion(), scale_matrix.to_scale())
         return matrix
 
     def draw(self, context):

--- a/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_gizmo.py
@@ -131,7 +131,7 @@ class MSFSGizmo:
         """
         for node in nodes:
             collisions = []  # TODO: make sure node is mesh?
-            for child in node.children:
+            for child in list(node.children):
                 blender_object = blender_scene.objects.get(
                     child.name
                 )  # The glTF exporter will ALWAYS set the node name as the blender name


### PR DESCRIPTION
Fixes #130
Partially fixes #137

Detailed list of fixes:

- Rotation is now taken into account for Blender gizmo preview
- Export all gizmo objects (issue was we were removing elements from a list we were currently enumerating)