### PR TITLE
Fix normal texture visibility in the viewport

### DIFF
--- a/addons/io_scene_gltf2_msfs/blender/msfs_material_function.py
+++ b/addons/io_scene_gltf2_msfs/blender/msfs_material_function.py
@@ -830,7 +830,6 @@ class MSFS_Material:
             'nodes["{0}"].inputs[1]'.format(MSFS_ShaderNodes.normalMapSampler.value),
         )
 
-        # tout ok ici 
         self.innerLink(
             'nodes["{0}"].outputs[0]'.format(MSFS_ShaderNodes.normalMapSampler.value),
             'nodes["{0}"].inputs[1]'.format(MSFS_ShaderNodes.blendNormalMap.value),

--- a/addons/io_scene_gltf2_msfs/blender/msfs_material_function.py
+++ b/addons/io_scene_gltf2_msfs/blender/msfs_material_function.py
@@ -84,7 +84,7 @@ class MSFS_ShaderNodes(Enum):
     emissiveTex = "Emissive Texture"
     emissiveColor = "Emissive RGB"
     emissiveScale = "Emissive Scale"
-    RGBCurves = "RGB Curves"
+    rgbCurves = "RGB Curves"
     emissiveMul = "Emissive Multiplier"
     normalMapSampler = "Normal Map Sampler"
     detailColorTex = "Detail Color(RGBA)"

--- a/addons/io_scene_gltf2_msfs/blender/msfs_material_function.py
+++ b/addons/io_scene_gltf2_msfs/blender/msfs_material_function.py
@@ -84,6 +84,7 @@ class MSFS_ShaderNodes(Enum):
     emissiveTex = "Emissive Texture"
     emissiveColor = "Emissive RGB"
     emissiveScale = "Emissive Scale"
+    RGBCurves = "RGB Curves"
     emissiveMul = "Emissive Multiplier"
     normalMapSampler = "Normal Map Sampler"
     detailColorTex = "Detail Color(RGBA)"
@@ -434,9 +435,22 @@ class MSFS_Material:
             "ShaderNodeNormalMap",
             {
                 "name": MSFS_ShaderNodes.normalMapSampler.value,
-                "location": (0.0, -900.0),
+                "location": (0.0, -1000.0),
             },
         )
+
+        # Fix the normal view by reversing the green channel
+        # since blender can only render openGL normal textures
+        nodeRGBCurves = self.addNode(
+            "ShaderNodeRGBCurve",
+            {
+                "name": MSFS_ShaderNodes.RGBCurves.value,
+                "location": (-200, -900.0),
+            },
+        )
+        curveMapping = nodeRGBCurves.mapping.curves[1]
+        curveMapping.points[0].location = (0,1)
+        curveMapping.points[1].location = (1,0)
 
         # detail alpha Operator
         self.blendAlphaMapNode = self.addNode(
@@ -808,8 +822,15 @@ class MSFS_Material:
 
         self.innerLink(
             'nodes["{0}"].outputs[0]'.format(MSFS_ShaderNodes.normalTex.value),
+            'nodes["{0}"].inputs[1]'.format(MSFS_ShaderNodes.RGBCurves.value),
+        )
+
+        self.innerLink(
+            'nodes["{0}"].outputs[0]'.format(MSFS_ShaderNodes.RGBCurves.value),
             'nodes["{0}"].inputs[1]'.format(MSFS_ShaderNodes.normalMapSampler.value),
         )
+
+        # tout ok ici 
         self.innerLink(
             'nodes["{0}"].outputs[0]'.format(MSFS_ShaderNodes.normalMapSampler.value),
             'nodes["{0}"].inputs[1]'.format(MSFS_ShaderNodes.blendNormalMap.value),


### PR DESCRIPTION
This PR add a new node "**RGB Curve**" that will invert the green channel of the Normal Texture
Since in the input we have a DirectX texture, we need to invert the green channel to see it correctly into blender which uses OpenGL

This is a Draft for now, as I need to be sure nothing has changed on the exporting process because of this fix

Feel Free to test it and add your feedback ;)