### PR TITLE
Blender 3.3 node rename - Lights , Readme - asset library - Normals

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Finally, you may also notice that some MSFS Material Parameters show data but *c
 
 <br>
 
+## Notes
+After migration or adding in asset groups the gLTF Settings node may have additional gLTF Settings that are numbered gLTF Setting.001, .002 etc. You need to review these node chnges as it will affect the COMP nodes in your project and the exporter will not export COMP nodes as expected.
+
 ## WARNING
 After migration SAVE YOUR FILE AS A NEW FILE and keep your legacy blend file for future reference.
 

--- a/addons/io_scene_gltf2_msfs/__init__.py
+++ b/addons/io_scene_gltf2_msfs/__init__.py
@@ -23,7 +23,7 @@ bl_info = {
     "author": "Luca Pierabella, Wing42, pepperoni505, ronh991, tml1024, and others",
     "description": "This toolkit prepares your 3D assets to be used for Microsoft Flight Simulator",
     "blender": (3, 1, 0),
-    "version": (1,1,6),
+    "version": (1,3,1),
     "location": "File > Import-Export",
     "category": "Import-Export",
     "tracker_url": "https://github.com/AsoboStudio/glTF-Blender-IO-MSFS"

--- a/addons/io_scene_gltf2_msfs/blender/msfs_material_panel.py
+++ b/addons/io_scene_gltf2_msfs/blender/msfs_material_panel.py
@@ -372,13 +372,11 @@ class MSFS_PT_Material(bpy.types.Panel):
                         else "",
                     )
 
-                # SSS params - disabled for now
-                # if mat.msfs_material_type in ["msfs_sss", "msfs_hair"]:
-                #     box = layout.box()
-                #     box.label(text="SSS Parameters")
-                #     self.draw_prop(
-                #         box, mat, "msfs_sss_color", enabled=False
-                #     )
+                # SSS params - disabled for now - not disabled
+                if mat.msfs_material_type in ["msfs_sss", "msfs_hair"]:
+                    box = layout.box()
+                    box.label(text="SSS Parameters")
+                    self.draw_prop(box, mat, "msfs_sss_color", enabled=False)
 
                 # Glass params
                 if mat.msfs_material_type == "msfs_glass":

--- a/addons/io_scene_gltf2_msfs/com/msfs_material_props.py
+++ b/addons/io_scene_gltf2_msfs/com/msfs_material_props.py
@@ -77,6 +77,16 @@ class AsoboMaterialCommon:
         update=MSFS_Material_Property_Update.update_emissive_color,
         options={"ANIMATABLE"},
     )
+    bpy.types.Material.msfs_color_sss = bpy.props.FloatVectorProperty(
+        name="SSS Color", 
+        description = "Use the color picker to set the color of the subsurface scattering.",
+        subtype='COLOR',
+        min=0.0, 
+        max=1.0,
+        size=4, 
+        default=Defaults.BaseColorFactor, 
+        update=MSFS_Material_Property_Update.update_color_sss
+    )
     bpy.types.Material.msfs_metallic_factor = bpy.props.FloatProperty(
         name="Metallic Factor",
         description="The metalness of the material. A value of 1.0 means the material is a metal. A value of 0.0 means the material is a dielectric. Values in between are for blending between metals and dielectrics such as dirty metallic surfaces. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the metallic texel values",
@@ -108,7 +118,7 @@ class AsoboMaterialCommon:
         name="Emissive Scale",
         description="The roughness of the material. A value of 1.0 means the material is completely rough. A value of 0.0 means the material is completely smooth. This value is linear. If a metallicRoughnessTexture is specified, this value is multiplied with the roughness texel values.",
         min=0.0,
-        max=1.0,
+        max=100.0,
         default=Defaults.EmissiveScale,
         update=MSFS_Material_Property_Update.update_emissive_scale,
         options=set(),

--- a/addons/io_scene_gltf2_msfs/io/msfs_light.py
+++ b/addons/io_scene_gltf2_msfs/io/msfs_light.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+import bpy
 
 from io_scene_gltf2.io.com.gltf2_io_extensions import Extension
 from mathutils import Matrix, Quaternion, Euler
@@ -50,9 +51,10 @@ class MSFSLight:
     def export(gltf2_object, blender_object):
         # First, clear all KHR_lights_punctual extensions from children. TODO: remove children?
         for child in gltf2_object.children:
-            if child.extensions and child.extensions.get("KHR_lights_punctual"):
-                child.extensions.pop("KHR_lights_punctual")
-
+            if child.extensions:
+                child.extensions.pop("KHR_lights_punctual", None)
+        gltf2_object.extensions.pop("KHR_lights_punctual", None)
+        
         angle = 360.0
         if blender_object.data.type == 'SPOT':
             angle = (180.0 / math.pi) * blender_object.data.spot_size
@@ -72,7 +74,7 @@ class MSFSLight:
         # start quick dirty fix to solve rotationn problem 
         # this can be removed after blender 3.2 goes out
         currentRotationQuat = Quaternion((gltf2_object.rotation[3],gltf2_object.rotation[0],gltf2_object.rotation[1],gltf2_object.rotation[2])) if gltf2_object.rotation  else Quaternion()
-        quat_a = Quaternion((1.0, 0.0, 0.0), math.radians(90.0))
+        quat_a = Quaternion((1.0, 0.0, 0.0), math.radians(90.0 if bpy.app.version < (3, 2, 0) else 180))
         r =  currentRotationQuat @ quat_a
         gltf2_object.rotation = [r.x,r.y,r.z,r.w]
         #end quick fix


### PR DESCRIPTION
A few updates rolled it this PR

issue 170 - I added a readme to talk about asset libraries possibly created in previous exporter versions.

issue 157 Normal

changed the version to 1.3.0 - the 3 representing Blender 3.3 ( 1.1.6 represented Blender 3.1) second version identifier is the second version id in Blender. - not sure I like that.

The shader node rename issue in blender 3.3

issue 176 SSS

Issue 164 - displacement

Let me know what to delete/remove